### PR TITLE
chore: remove unused `resourceType` property

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -2,16 +2,10 @@ import intoStream from 'into-stream'
 import { open } from 'yauzl-promise'
 
 import { validateStyle } from './utils/style.js'
-import {
-  getContentType,
-  getResourceType,
-  STYLE_FILE,
-  URI_BASE,
-} from './utils/templates.js'
+import { getContentType, STYLE_FILE, URI_BASE } from './utils/templates.js'
 
 /**
  * @typedef {object} Resource
- * @property {string} resourceType
  * @property {string} contentType
  * @property {number} contentLength
  * @property {import('stream').Readable} stream
@@ -90,7 +84,6 @@ export default class Reader {
     return {
       contentType: 'application/json; charset=utf-8',
       contentLength: Buffer.byteLength(transformedStyleJSON, 'utf8'),
-      resourceType: 'style',
       stream: intoStream(transformedStyleJSON),
     }
   }
@@ -107,12 +100,10 @@ export default class Reader {
     if (path === STYLE_FILE) return this.getStyle()
     const entry = (await this.#entriesPromise).get(path)
     if (!entry) throw new Error(`File not found: ${path}`)
-    const resourceType = getResourceType(path)
     const contentType = getContentType(path)
     const stream = await entry.openReadStream()
     /** @type {Resource} */
     const resource = {
-      resourceType,
       contentType,
       contentLength: entry.uncompressedSize,
       stream,

--- a/lib/utils/templates.js
+++ b/lib/utils/templates.js
@@ -20,24 +20,6 @@ const SPRITE_FILE = SPRITES_FOLDER + '/{id}/sprite{pixelRatio}{ext}'
 const GLYPH_FILE = FONTS_FOLDER + '/{fontstack}/{range}.pbf.gz'
 export const GLYPH_URI = URI_BASE + GLYPH_FILE
 
-const pathToResouceType = /** @type {const} */ ({
-  [TILE_FILE.split('/')[0] + '/']: 'tile',
-  [SPRITE_FILE.split('/')[0] + '/']: 'sprite',
-  [GLYPH_FILE.split('/')[0] + '/']: 'glyph',
-})
-
-/**
- * @param {string} path
- * @returns
- */
-export function getResourceType(path) {
-  if (path === 'style.json') return 'style'
-  for (const [prefix, type] of Object.entries(pathToResouceType)) {
-    if (path.startsWith(prefix)) return type
-  }
-  throw new Error(`Unknown resource type for path: ${path}`)
-}
-
 /**
  * Determine the content type of a file based on its extension.
  *


### PR DESCRIPTION
This change should have no impact on functionality.

`Resource` had an unused property, `resourceType`, which we can remove.
