### PR TITLE
chore: ensure `Writer` methods return `Promise<void>`

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -116,6 +116,7 @@ export default class Writer extends EventEmitter {
    *
    * @param {string} sourceId
    * @param {TileSource} source
+   * @returns {void}
    */
   addSource(sourceId, source) {
     if (source.type !== 'raster' && source.type !== 'vector') {
@@ -201,12 +202,13 @@ export default class Writer extends EventEmitter {
    * @param {Source} options.png
    * @param {number} options.pixelRatio
    * @param {string} [options.id='default']
+   * @returns {Promise<void>}
    */
-  addSprite({ json, png, pixelRatio, id = 'default' }) {
+  async addSprite({ json, png, pixelRatio, id = 'default' }) {
     this.#addedSpriteIds.add(id)
     const jsonName = getSpriteFilename({ id, pixelRatio, ext: '.json' })
     const pngName = getSpriteFilename({ id, pixelRatio, ext: '.png' })
-    return Promise.all([
+    await Promise.all([
       this.#append(json, { name: jsonName }),
       this.#append(png, { name: pngName }),
     ])
@@ -219,6 +221,7 @@ export default class Writer extends EventEmitter {
    * @param {object} options
    * @param {string} options.font
    * @param {GlyphRange} options.range
+   * @returns {Promise<void>}
    */
   addGlyphs(glyphData, { font: fontName, range }) {
     this.#fonts.add(fontName)
@@ -316,14 +319,20 @@ export default class Writer extends EventEmitter {
    *
    * @param {Source} source
    * @param {{ name: string, store?: boolean }} options
+   * @returns {Promise<void>}
    */
   async #append(source, { name, store = false }) {
     if (this.#addedFiles.has(name)) {
       throw new Error(`${name} already added`)
     }
     this.#addedFiles.add(name)
+    const onAdded = pEvent(
+      this.#archive,
+      'entry',
+      (entry) => entry.name === name,
+    )
     this.#archive.append(convertSource(source), { name, store })
-    return pEvent(this.#archive, 'entry', (entry) => entry.name === name)
+    await onAdded
   }
 }
 


### PR DESCRIPTION
Vairous `Writer` methods were returning `Promise<any>` because of what `Writer.prototype.#append` returned. I think `Promise<void>` was the intent, so I (1) added explicit returns to relevant functions (2) made sure functions actually returned those values.

I also switched the order of the event listener in `#append`, just in case the `entry` event is emitted synchronously.