### PR TITLE
chore: remove nested ternary from `Writer`

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -148,12 +148,14 @@ export default class Writer extends EventEmitter {
     source.maxzoom = Math.max(source.maxzoom, z)
 
     if (!format) {
-      const tileDataStream =
-        typeof tileData === 'string'
-          ? fs.createReadStream(tileData)
-          : tileData instanceof Uint8Array
-            ? Readable.from(tileData)
-            : tileData
+      /** @type {Readable} */ let tileDataStream
+      if (typeof tileData === 'string') {
+        tileDataStream = fs.createReadStream(tileData)
+      } else if (tileData instanceof Uint8Array) {
+        tileDataStream = Readable.from(tileData)
+      } else {
+        tileDataStream = tileData
+      }
       ;[format, tileData] = await getTileFormatFromStream(tileDataStream)
     }
 


### PR DESCRIPTION
*Feel free to close this if you disagree—this is purely code style.*

This change should have no impact on functionality.

I find nested ternary expressions hard to read, so this removes it.
