### PR TITLE
chore: tweak `getFormatFromMimeType` fetching

### DIFF
--- a/lib/utils/file-formats.js
+++ b/lib/utils/file-formats.js
@@ -1,5 +1,7 @@
 import BufferPeerStream from 'buffer-peek-stream'
 
+import { hasOwn } from './misc.js'
+
 const peek = BufferPeerStream.promise
 
 const MAGIC_BYTES = /** @type {const} */ ({
@@ -34,7 +36,6 @@ for (const [ext, bytes] of Object.entries(MAGIC_BYTES)) {
  * @param {Buffer | Uint8Array} buf
  * @returns {import("../writer.js").TileFormat}
  */
-
 export function getTileFormatFromBuffer(buf) {
   const ext = magicByteMap.get(buf[0])
   if (!ext) {
@@ -79,7 +80,6 @@ export async function getTileFormatFromStream(tileData) {
  */
 export function getFormatFromMimeType(mimeType) {
   if (mimeType.startsWith('application/')) return 'mvt'
-  // @ts-ignore
-  if (mimeType in MIME_TYPES) return MIME_TYPES[mimeType]
+  if (hasOwn(MIME_TYPES, mimeType)) return MIME_TYPES[mimeType]
   throw new Error('Unsupported MIME type ' + mimeType)
 }

--- a/lib/utils/misc.js
+++ b/lib/utils/misc.js
@@ -12,3 +12,15 @@ export function clone(obj) {
 }
 
 export function noop() {}
+
+/**
+ * Like `Object.hasOwn`, but refines the type of `key`.
+ *
+ * @template {Record<string, unknown>} T
+ * @param {T} obj
+ * @param {string} key
+ * @returns {key is (keyof T)}
+ */
+export function hasOwn(obj, key) {
+  return Object.hasOwn(obj, key)
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2021",
-    "lib": ["ES2021", "dom"],
+    "lib": ["ES2022", "dom"],
     "strict": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
`getFormatFromMimeType` had two small problems:

- If `mimeType` was on `Object.prototype` (such as `constructor` or `hasOwnProperty`), something unexpected could occur.
- It had a `ts-ignore`, impacting type safety.

This fixes both of those.
