### PR TITLE
chore: update package lock with correct license

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "styled-map-package",
       "version": "1.0.0-pre.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "@fastify/static": "^7.0.4",
         "@mapbox/sphericalmercator": "^1.2.0",


### PR DESCRIPTION
Package lock license was outdated compared to package.json