### PR TITLE
fix: include type definitions when publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Thumbs.db
 
 # SMP artifacts from testing
 /*.smp
+
+# Published directory for type definitions
+dist/

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,6 @@
+/** @typedef {import('./types.js').SMPSource} SMPSource */
+/** @typedef {import('./types.js').SMPStyle} SMPStyle */
+
 export { default as Reader } from './reader.js'
 export { default as Writer } from './writer.js'
 export { default as Server } from './server.js'

--- a/lib/utils/streams.js
+++ b/lib/utils/streams.js
@@ -1,5 +1,7 @@
 import { Readable, Writable, Transform } from 'readable-stream'
 
+/** @import { TransformOptions } from 'readable-stream' */
+
 /**
  * Create a writable stream from an async function. Default concurrecy is 16 -
  * this is the number of parallel functions that will be pending before
@@ -121,21 +123,23 @@ export function isWebReadableStream(obj) {
 }
 
 /** @typedef {(opts: { totalBytes: number, chunkBytes: number }) => void} ProgressCallback */
+/** @typedef {TransformOptions & { onprogress?: ProgressCallback }} ProgressStreamOptions */
 
 /**
  * Passthrough stream that counts the bytes passing through it. Pass an optional
  * `onprogress` callback that will be called with the accumulated total byte
  * count and the chunk byte count after each chunk.
+ * @extends {Transform}
  */
 export class ProgressStream extends Transform {
   #onprogress
   #byteLength = 0
 
   /**
-   * @param {{ onprogress?: ProgressCallback}} [opts]
+   * @param {ProgressStreamOptions} [opts]
    */
-  constructor({ onprogress } = {}) {
-    super()
+  constructor({ onprogress, ...opts } = {}) {
+    super(opts)
     this.#onprogress = onprogress
   }
 

--- a/lib/utils/streams.js
+++ b/lib/utils/streams.js
@@ -1,7 +1,5 @@
 import { Readable, Writable, Transform } from 'readable-stream'
 
-/** @import { TransformOptions } from 'readable-stream' */
-
 /**
  * Create a writable stream from an async function. Default concurrecy is 16 -
  * this is the number of parallel functions that will be pending before
@@ -134,10 +132,10 @@ export class ProgressStream extends Transform {
   #byteLength = 0
 
   /**
-   * @param {TransformOptions & { onprogress?: ProgressCallback }} [opts]
+   * @param {{ onprogress?: ProgressCallback}} [opts]
    */
-  constructor({ onprogress, ...opts } = {}) {
-    super(opts)
+  constructor({ onprogress } = {}) {
+    super()
     this.#onprogress = onprogress
   }
 

--- a/lib/utils/streams.js
+++ b/lib/utils/streams.js
@@ -147,6 +147,7 @@ export class ProgressStream extends Transform {
   }
 
   /**
+   * @override
    * @param {Buffer | Uint8Array} chunk
    * @param {Parameters<Transform['_transform']>[1]} encoding
    * @param {Parameters<Transform['_transform']>[2]} callback

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
         "yocto-queue": "^1.1.1"
       },
       "bin": {
-        "smp": "bin/smp.js"
+        "smp": "bin/smp.js",
+        "styled-map-package": "bin/smp.js"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "png-stream": "^1.0.5",
         "prettier": "^3.3.3",
         "random-bytes-readable-stream": "^3.0.0",
+        "rimraf": "^4.4.1",
         "type-fest": "^4.26.0",
         "typescript": "5.5.4"
       }
@@ -791,6 +792,45 @@
       },
       "bin": {
         "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@mapbox/sphericalmercator": {
@@ -5531,40 +5571,77 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
     },
     "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
+      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "glob": "^7.1.3"
+        "glob": "^9.2.0"
       },
       "bin": {
-        "rimraf": "bin.js"
+        "rimraf": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/run-applescript": {
@@ -7381,6 +7458,31 @@
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
         "tar": "^6.1.11"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "@mapbox/sphericalmercator": {
@@ -10700,27 +10802,49 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
     },
     "rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-4.4.1.tgz",
+      "integrity": "sha512-Gk8NlF062+T9CqNGn6h4tls3k6T1+/nXdOcSZVikNVtlRdYpA7wRJJMoXmuvOnLW844rPjdQ7JgXCYM6PPC/og==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.3"
+        "glob": "^9.2.0"
       },
       "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
         "glob": {
-          "version": "7.2.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "version": "9.3.5",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+          "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.1.1",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "minimatch": "^8.0.2",
+            "minipass": "^4.2.4",
+            "path-scurry": "^1.6.1"
           }
+        },
+        "minimatch": {
+          "version": "8.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+          "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "minipass": {
+          "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+          "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test": "npm run lint && node --test",
     "prepare": "husky",
     "lint": "eslint .",
+    "types": "tsc",
     "build:types": "tsc -p tsconfig.publish.json"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "map-viewer"
   ],
   "scripts": {
-    "test": "npm run lint && node --test",
+    "test": "npm run lint && npm run types && node --test",
     "prepare": "husky",
     "lint": "eslint .",
     "types": "tsc",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
     "smp": "./bin/smp.js"
   },
   "type": "module",
+  "files": [
+    "map-viewer",
+    "bin",
+    "lib",
+    "dist"
+  ],
   "scripts": {
     "test": "npm run lint && node --test",
     "prepare": "husky",

--- a/package.json
+++ b/package.json
@@ -7,27 +7,27 @@
       "types": "./dist/index.d.ts",
       "import": "./lib/index.js"
     },
-    "./reader.js": {
+    "./reader": {
       "types": "./dist/reader.d.ts",
       "import": "./lib/reader.js"
     },
-    "./writer.js": {
+    "./writer": {
       "types": "./dist/writer.d.ts",
       "import": "./lib/writer.js"
     },
-    "./server.js": {
+    "./server": {
       "types": "./dist/server.d.ts",
       "import": "./lib/server.js"
     },
-    "./style-downloader.js": {
+    "./style-downloader": {
       "types": "./dist/style-downloader.d.ts",
       "import": "./lib/style-downloader.js"
     },
-    "./tile-downloader.js": {
+    "./tile-downloader": {
       "types": "./dist/tile-downloader.d.ts",
       "import": "./lib/tile-downloader.js"
     },
-    "./download.js": {
+    "./download": {
       "types": "./dist/download.d.ts",
       "import": "./lib/download.js"
     }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
       "import": "./lib/download.js"
     }
   },
+  "main": "./lib/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
     "styled-map-package": "./bin/smp.js",

--- a/package.json
+++ b/package.json
@@ -3,14 +3,36 @@
   "version": "1.0.1",
   "description": "",
   "exports": {
-    ".": "./lib/index.js",
-    "./reader": "./lib/reader.js",
-    "./writer": "./lib/writer.js",
-    "./server": "./lib/server.js",
-    "./style-downloader": "./lib/style-downloader.js",
-    "./tile-downloader": "./lib/tile-downloader.js",
-    "./download": "./lib/download.js"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./lib/index.js"
+    },
+    "./reader.js": {
+      "types": "./dist/reader.d.ts",
+      "import": "./lib/reader.js"
+    },
+    "./writer.js": {
+      "types": "./dist/writer.d.ts",
+      "import": "./lib/writer.js"
+    },
+    "./server.js": {
+      "types": "./dist/server.d.ts",
+      "import": "./lib/server.js"
+    },
+    "./style-downloader.js": {
+      "types": "./dist/style-downloader.d.ts",
+      "import": "./lib/style-downloader.js"
+    },
+    "./tile-downloader.js": {
+      "types": "./dist/tile-downloader.d.ts",
+      "import": "./lib/tile-downloader.js"
+    },
+    "./download.js": {
+      "types": "./dist/download.d.ts",
+      "import": "./lib/download.js"
+    }
   },
+  "types": "./dist/index.d.ts",
   "bin": {
     "styled-map-package": "./bin/smp.js",
     "smp": "./bin/smp.js"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "prepare": "husky",
     "lint": "eslint .",
     "types": "tsc",
-    "build:types": "tsc -p tsconfig.publish.json"
+    "build:types": "rimraf \"dist/\" && tsc -p tsconfig.publish.json",
+    "prepack": "npm run build:types"
   },
   "keywords": [],
   "author": "",
@@ -88,6 +89,7 @@
     "png-stream": "^1.0.5",
     "prettier": "^3.3.3",
     "random-bytes-readable-stream": "^3.0.0",
+    "rimraf": "^4.4.1",
     "type-fest": "^4.26.0",
     "typescript": "5.5.4"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "scripts": {
     "test": "npm run lint && node --test",
     "prepare": "husky",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "build:types": "tsc -p tsconfig.publish.json"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "type": "module",
   "files": [
-    "map-viewer",
     "bin",
+    "dist",
     "lib",
-    "dist"
+    "map-viewer"
   ],
   "scripts": {
     "test": "npm run lint && node --test",

--- a/test/utils/digest-stream.js
+++ b/test/utils/digest-stream.js
@@ -12,6 +12,7 @@ export class DigestStream extends Transform {
     this.#hash = createHash(algorithm)
   }
   /**
+   * @override
    * @param {*} chunk
    * @param {BufferEncoding} encoding
    * @param {import('node:stream').TransformCallback} callback

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,20 @@
 {
   "compilerOptions": {
-    "target": "ES2021",
-    "lib": ["ES2022", "dom"],
-    "strict": true,
-    "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true,
-    "module": "ES2022",
-    "moduleResolution": "node",
+    "target": "es2022",
+    "lib": ["es2022"],
+
     "allowJs": true,
     "checkJs": true,
+    "module": "NodeNext",
+    "moduleDetection": "force",
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
     "noEmit": true,
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
     "skipLibCheck": true,
     "typeRoots": ["types", "node_modules/@types"]
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,6 @@
     "noEmit": true,
 
     "strict": true,
-    "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
 
     "skipLibCheck": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
 
     "strict": true,
     "noImplicitOverride": true,
+    "forceConsistentCasingInFileNames": true,
 
     "skipLibCheck": true,
     "typeRoots": ["types", "node_modules/@types"]

--- a/tsconfig.publish.json
+++ b/tsconfig.publish.json
@@ -6,5 +6,5 @@
     "emitDeclarationOnly": true,
     "outDir": "dist"
   },
-  "include": ["lib/**/*"]
+  "include": ["lib/**/*", "types/**/*"]
 }

--- a/tsconfig.publish.json
+++ b/tsconfig.publish.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  },
+  "include": ["lib/**/*"]
+}

--- a/tsconfig.publish.json
+++ b/tsconfig.publish.json
@@ -4,6 +4,7 @@
     "noEmit": false,
     "declaration": true,
     "emitDeclarationOnly": true,
+    "noEmitOnError": true,
     "outDir": "dist"
   },
   "include": ["lib/**/*", "types/**/*"]


### PR DESCRIPTION
Mainly:

- Sets up type defs generation
- Updates npm package setup to include generated types
- ~**BREAKING CHANGE**: renames the exports to include the `.js` suffix at the end, which I believe is generally recommended/idiomatic. Not strictly necessary for us to do so open to reverting that change if preferred~ EDIT: reverted

Should introduce `noUncheckedIndexedAccess` in the tsconfig as a follow-up but it will lead to errors that will require code changes outside the scope of this PR.