### PR TITLE
fix: fastify plugin should work with prefixed routes

### DIFF
--- a/bin/smp-view.js
+++ b/bin/smp-view.js
@@ -47,6 +47,7 @@ function serve({ port = 3000, filepath }) {
 
   server.register(smpServer, {
     filepath: path.relative(process.cwd(), filepath),
+    prefix: '/map',
   })
   return server.listen({ port })
 }

--- a/lib/reader.js
+++ b/lib/reader.js
@@ -146,5 +146,8 @@ function getUrl(smpUri, baseUrl) {
     throw new Error(`Invalid SMP URI: ${smpUri}`)
   }
   if (typeof baseUrl !== 'string') return smpUri
-  return smpUri.replace(URI_BASE, baseUrl + '/')
+  if (!baseUrl.endsWith('/')) {
+    baseUrl += '/'
+  }
+  return smpUri.replace(URI_BASE, baseUrl)
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,12 +1,14 @@
-/**
- * @typedef {object} PluginOptions
- * @property {string} filepath
- * @property {boolean} [lazy=false]
- */
 import Reader from './reader.js'
 
 /** @import { FastifyPluginCallback, FastifyReply } from 'fastify' */
 /** @import { Resource } from './reader.js' */
+
+/**
+ * @typedef {object} PluginOptions
+ * @property {boolean} [lazy=false]
+ * @property {string} [prefix]
+ * @property {string} filepath Path to styled map package (`.smp`) file
+ */
 
 /**
  * @param {FastifyReply} reply
@@ -29,7 +31,7 @@ function sendResource(reply, resource) {
  *
  * @type {FastifyPluginCallback<PluginOptions>}
  */
-export default function (fastify, { filepath, lazy = false }, done) {
+export default function (fastify, { lazy = false, filepath }, done) {
   /** @type {Reader | undefined} */
   let reader
   if (!lazy) {
@@ -40,18 +42,21 @@ export default function (fastify, { filepath, lazy = false }, done) {
     if (!reader) {
       reader = new Reader(filepath)
     }
-    return reader.getStyle(fastify.listeningOrigin)
+    const baseUrl = new URL(fastify.prefix, fastify.listeningOrigin)
+    return reader.getStyle(baseUrl.href)
   })
 
   fastify.get('*', async (request, reply) => {
     if (!reader) {
       reader = new Reader(filepath)
     }
+    // @ts-expect-error - not worth the hassle of type casting this
+    const path = request.params['*']
 
     /** @type {Resource} */
     let resource
     try {
-      resource = await reader.getResource(decodeURI(request.url))
+      resource = await reader.getResource(path)
     } catch (e) {
       // @ts-ignore
       e.statusCode = 404

--- a/map-viewer/index.html
+++ b/map-viewer/index.html
@@ -31,7 +31,7 @@
 
       const map = new maplibregl.Map({
         container: 'map',
-        style: 'style.json',
+        style: 'map/style.json',
       })
 
       map.on('error', (e) => {


### PR DESCRIPTION
Since the fastify plugin here is not wrapped with `@fastify/plugin` (it doesn't need to be, because it doesn't need to break encapsulation), passing `prefix` "just works".

I can't find `request.params['*']` documented anywhere, but [`@fastify/static` uses it](https://github.com/fastify/fastify-static/blob/c0ca1c99dd0272d80d72f1be97304182f53bd92d/index.js#L118) so I assume it's ok.