### PR TITLE
feat(server): handle file replacement after server initialization

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -3,6 +3,7 @@ import { open } from 'yauzl-promise'
 
 import { json } from 'node:stream/consumers'
 
+import { ENOENT } from './utils/errors.js'
 import { noop } from './utils/misc.js'
 import { validateStyle } from './utils/style.js'
 import {
@@ -57,6 +58,14 @@ export default class Reader {
   }
 
   /**
+   * Resolves when the styled map package has been opened and the entries have
+   * been read. Throws any error that occurred during opening.
+   */
+  async opened() {
+    await this.#entriesPromise
+  }
+
+  /**
    * Get the style JSON from the styled map package. The URLs in the style JSON
    * will be transformed to use the provided base URL.
    *
@@ -65,7 +74,7 @@ export default class Reader {
    */
   async getStyle(baseUrl = null) {
     const styleEntry = (await this.#entriesPromise).get(STYLE_FILE)
-    if (!styleEntry) throw new Error(`File not found: ${STYLE_FILE}`)
+    if (!styleEntry) throw new ENOENT(STYLE_FILE)
     const stream = await styleEntry.openReadStream()
     const style = await json(stream)
     if (!validateStyle(style)) {
@@ -110,7 +119,7 @@ export default class Reader {
       }
     }
     const entry = (await this.#entriesPromise).get(path)
-    if (!entry) throw new Error(`File not found: ${path}`)
+    if (!entry) throw new ENOENT(path)
     const resourceType = getResourceType(path)
     const contentType = getContentType(path)
     const stream = await entry.openReadStream()

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,3 +1,5 @@
+import createError from 'http-errors'
+
 import Reader from './reader.js'
 import { noop } from './utils/misc.js'
 
@@ -34,43 +36,81 @@ function sendResource(reply, resource) {
  */
 export default function (fastify, { lazy = false, filepath }, done) {
   /** @type {Reader | undefined} */
-  let reader
+  let _reader
+  /** @type {Promise<Reader> | undefined} */
+  let _readerOpeningPromise
+
+  async function getReader() {
+    // A lovely promise tangle to confuse future readers... sorry.
+    //
+    // 1. If the reader is already open, return it.
+    // 2. If the reader is in the process of opening, return a promise that will
+    //    return the reader instance if it opened without error, or throw.
+    // 3. If the reader threw an error during opening, try to open it again next
+    //    time this is called.
+    if (_reader) return _reader
+    if (_readerOpeningPromise) return _readerOpeningPromise
+    const maybeReader = new Reader(filepath)
+    _readerOpeningPromise = maybeReader
+      .opened()
+      .then(() => {
+        _reader = maybeReader
+        return _reader
+      })
+      .finally(() => {
+        _readerOpeningPromise = undefined
+      })
+    return _readerOpeningPromise
+  }
+
   if (!lazy) {
-    reader = new Reader(filepath)
+    getReader().catch(noop)
   }
 
   fastify.addHook('onClose', async () => {
-    if (reader) {
-      await reader.close().catch(noop)
+    try {
+      const reader = await getReader()
+      await reader.close()
+    } catch {
+      // ignore
     }
   })
 
   fastify.get('/style.json', async () => {
-    if (!reader) {
-      reader = new Reader(filepath)
+    try {
+      const reader = await getReader()
+      const baseUrl = new URL(fastify.prefix, fastify.listeningOrigin)
+      return reader.getStyle(baseUrl.href)
+    } catch (error) {
+      if (isENOENT(error)) {
+        throw createError(404, error.message)
+      }
+      throw error
     }
-    const baseUrl = new URL(fastify.prefix, fastify.listeningOrigin)
-    return reader.getStyle(baseUrl.href)
   })
 
   fastify.get('*', async (request, reply) => {
-    if (!reader) {
-      reader = new Reader(filepath)
-    }
     // @ts-expect-error - not worth the hassle of type casting this
     const path = request.params['*']
 
-    /** @type {Resource} */
-    let resource
     try {
-      resource = await reader.getResource(path)
-    } catch (e) {
-      // @ts-ignore
-      e.statusCode = 404
-      throw e
+      const reader = await getReader()
+      const resource = await reader.getResource(path)
+      return sendResource(reply, resource)
+    } catch (error) {
+      if (isENOENT(error)) {
+        throw createError(404, error.message)
+      }
+      throw error
     }
-
-    return sendResource(reply, resource)
   })
   done()
+}
+
+/**
+ * @param {unknown} error
+ * @returns {error is Error & { code: 'ENOENT' }}
+ */
+function isENOENT(error) {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT'
 }

--- a/lib/utils/errors.js
+++ b/lib/utils/errors.js
@@ -1,0 +1,9 @@
+export class ENOENT extends Error {
+  code = 'ENOENT'
+  /** @param {string} path */
+  constructor(path) {
+    const message = `ENOENT: no such file or directory, open '${path}'`
+    super(message)
+    this.path = path
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "commander": "^12.1.0",
         "fastify": "^4.28.1",
         "filter-obj": "^6.1.0",
+        "http-errors": "^2.0.0",
         "into-stream": "^8.0.1",
         "is-stream": "^4.0.1",
         "ky": "^1.7.1",
@@ -52,6 +53,7 @@
         "@types/eslint": "^9.6.1",
         "@types/eslint__js": "^8.42.3",
         "@types/geojson": "^7946.0.14",
+        "@types/http-errors": "^2.0.4",
         "@types/mapbox__sphericalmercator": "^1.2.3",
         "@types/node": "^20.16.3",
         "@types/readable-stream": "^4.0.15",
@@ -70,6 +72,7 @@
         "prettier": "^3.3.3",
         "random-bytes-readable-stream": "^3.0.0",
         "rimraf": "^4.4.1",
+        "tempy": "^3.1.0",
         "type-fest": "^4.26.0",
         "typescript": "5.5.4"
       }
@@ -1339,6 +1342,13 @@
       "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg==",
       "license": "MIT"
     },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2484,6 +2494,35 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/crypto-random-string/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/currently-unhandled": {
@@ -3755,6 +3794,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
         "inherits": "2.0.4",
@@ -6437,6 +6477,51 @@
         "node": ">=14.16"
       }
     },
+    "node_modules/tempy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+      "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/tempy/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/text-decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
@@ -6601,6 +6686,22 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crypto-random-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/uri-js": {
@@ -7951,6 +8052,12 @@
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
       "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
+    "@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -8810,6 +8917,23 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
+      }
+    },
+    "crypto-random-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^1.0.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+          "dev": true
+        }
       }
     },
     "currently-unhandled": {
@@ -11540,6 +11664,32 @@
       "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
       "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw=="
     },
+    "tempy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+      "integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+      "dev": true,
+      "requires": {
+        "is-stream": "^3.0.0",
+        "temp-dir": "^3.0.0",
+        "type-fest": "^2.12.2",
+        "unique-string": "^3.0.0"
+      },
+      "dependencies": {
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+          "dev": true
+        }
+      }
+    },
     "text-decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.1.1.tgz",
@@ -11664,6 +11814,15 @@
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
+      }
+    },
+    "unique-string": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+      "dev": true,
+      "requires": {
+        "crypto-random-string": "^4.0.0"
       }
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "commander": "^12.1.0",
     "fastify": "^4.28.1",
     "filter-obj": "^6.1.0",
+    "http-errors": "^2.0.0",
     "into-stream": "^8.0.1",
     "is-stream": "^4.0.1",
     "ky": "^1.7.1",
@@ -96,6 +97,7 @@
     "@types/eslint": "^9.6.1",
     "@types/eslint__js": "^8.42.3",
     "@types/geojson": "^7946.0.14",
+    "@types/http-errors": "^2.0.4",
     "@types/mapbox__sphericalmercator": "^1.2.3",
     "@types/node": "^20.16.3",
     "@types/readable-stream": "^4.0.15",
@@ -114,6 +116,7 @@
     "prettier": "^3.3.3",
     "random-bytes-readable-stream": "^3.0.0",
     "rimraf": "^4.4.1",
+    "tempy": "^3.1.0",
     "type-fest": "^4.26.0",
     "typescript": "5.5.4"
   },

--- a/test/reader.js
+++ b/test/reader.js
@@ -32,7 +32,7 @@ test('Reader, invalid smp file', async () => {
   // check zip file is valid
   const entries = await zip.readEntries()
   assert(entries.find((entry) => entry.filename === 'file2.txt'))
-  const expectedError = { message: /File not found/ }
+  const expectedError = { code: 'ENOENT' }
   const reader = new Reader(zip)
   await assert.rejects(reader.getStyle(), expectedError)
   await assert.rejects(reader.getResource('/style.json'), expectedError)

--- a/test/server.js
+++ b/test/server.js
@@ -1,19 +1,23 @@
 import { execa } from 'execa'
 import createFastify from 'fastify'
+import { temporaryFile, temporaryWrite } from 'tempy'
 
 import assert from 'node:assert/strict'
+import { randomBytes } from 'node:crypto'
+import fsPromises from 'node:fs/promises'
 import { test } from 'node:test'
 
 import createServer from '../lib/server.js'
 import { validateStyle } from '../lib/utils/style.js'
 import { replaceVariables } from '../lib/utils/templates.js'
 
-test('server basic', async () => {
+test('server basic', async (t) => {
   const filepath = new URL('./fixtures/demotiles-z2.smp', import.meta.url)
     .pathname
   const fastify = createFastify()
   fastify.register(createServer, { filepath })
   await fastify.listen()
+  t.after(() => fastify.close())
   const response = await fastify.inject({ url: '/style.json' })
   assert.equal(response.statusCode, 200)
   assert.equal(
@@ -68,7 +72,6 @@ test('server basic', async () => {
       'Content-Length header is correct',
     )
   }
-  await fastify.close()
 })
 
 test('server.close() closes reader', { skip: isWin() }, async () => {
@@ -95,24 +98,78 @@ test('server lazy', { skip: isWin() }, async () => {
   assert.equal(await fdCount(filepath), 0)
 })
 
-test('server invalid filepath', async () => {
+test('server invalid filepath', async (t) => {
   const filepath = 'invalid_file_path'
   const fastify = createFastify()
   fastify.register(createServer, { filepath })
   await fastify.listen()
+  t.after(() => fastify.close())
   const response = await fastify.inject({ url: '/style.json' })
-  assert.equal(response.statusCode, 500)
-  await fastify.close()
+  assert.equal(response.statusCode, 404)
 })
 
-test('server invalid file', async () => {
-  const filepath = '/dev/null'
+test('server invalid file', async (t) => {
+  const filepath = await temporaryWrite(randomBytes(1024))
   const fastify = createFastify()
   fastify.register(createServer, { filepath })
   await fastify.listen()
+  t.after(() => fastify.close())
   const response = await fastify.inject({ url: '/style.json' })
   assert.equal(response.statusCode, 500)
-  await fastify.close()
+})
+
+test('server file present after server starts', async (t) => {
+  const filepath = temporaryFile()
+  const smpFixtureFilepath = new URL(
+    './fixtures/demotiles-z2.smp',
+    import.meta.url,
+  ).pathname
+
+  const fastify = createFastify()
+  fastify.register(createServer, { filepath })
+  await fastify.listen()
+  t.after(() => fastify.close())
+
+  await t.test('file is not present initially', async () => {
+    const response = await fastify.inject({ url: '/style.json' })
+    assert.equal(response.statusCode, 404)
+    assert.match(response.json().error, /Not Found/)
+  })
+
+  await t.test('file is added after server starts', async () => {
+    await fsPromises.copyFile(smpFixtureFilepath, filepath)
+
+    const response = await fastify.inject({ url: '/style.json' })
+    assert.equal(response.statusCode, 200)
+    assert(validateStyle(response.json()))
+  })
+})
+
+test('invalid file replaced after server starts', async (t) => {
+  const filepath = await temporaryWrite(randomBytes(1024))
+  const smpFixtureFilepath = new URL(
+    './fixtures/demotiles-z2.smp',
+    import.meta.url,
+  ).pathname
+
+  const fastify = createFastify()
+  fastify.register(createServer, { filepath })
+  await fastify.listen()
+  t.after(() => fastify.close())
+
+  await t.test('file is not present initially', async () => {
+    const response = await fastify.inject({ url: '/style.json' })
+    assert.equal(response.statusCode, 500)
+    assert.match(response.json().error, /Internal Server Error/)
+  })
+
+  await t.test('file is added after server starts', async () => {
+    await fsPromises.copyFile(smpFixtureFilepath, filepath)
+
+    const response = await fastify.inject({ url: '/style.json' })
+    assert.equal(response.statusCode, 200)
+    assert(validateStyle(response.json()))
+  })
 })
 
 /** @returns {boolean} */


### PR DESCRIPTION
This solves the problem of the server plugin being initialized with a filepath pointing to a file that is invalid or missing, and then the file being added at a later date.

I initially implemented this in the `Reader` class (https://github.com/digidem/styled-map-package/pull/24), but it didn't feel right because it does not really belong there - it's solving a specific problem which is nothing to do with the functionality of `Reader`.

Instead this PR solves the problem within the server plugin. It cleans up error codes too.
