### PR TITLE
feat!: Remove lazy option for server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -8,7 +8,6 @@ import { noop } from './utils/misc.js'
 
 /**
  * @typedef {object} PluginOptions
- * @property {boolean} [lazy=false]
  * @property {string} [prefix]
  * @property {string} filepath Path to styled map package (`.smp`) file
  */
@@ -34,8 +33,8 @@ function sendResource(reply, resource) {
  *
  * @type {FastifyPluginCallback<PluginOptions>}
  */
-export default function (fastify, { lazy = false, filepath }, done) {
-  const deferredReader = new DeferredReader(filepath, { lazy })
+export default function (fastify, { filepath }, done) {
+  const deferredReader = new DeferredReader(filepath)
 
   fastify.addHook('onClose', async () => {
     try {
@@ -94,14 +93,10 @@ class DeferredReader {
 
   /**
    * @param {string} filepath
-   * @param {object} opts
-   * @param {boolean} [opts.lazy=false]
    */
-  constructor(filepath, { lazy = false } = {}) {
+  constructor(filepath) {
     this.#filepath = filepath
-    if (!lazy) {
-      this.get().catch(noop)
-    }
+    this.get().catch(noop)
   }
 
   async get() {

--- a/test/server.js
+++ b/test/server.js
@@ -88,19 +88,6 @@ test('server.close() closes reader', { skip: isWin() }, async () => {
   assert.equal(await fdCount(filepath), 0)
 })
 
-test('server lazy', { skip: isWin() }, async () => {
-  const filepath = new URL('./fixtures/demotiles-z2.smp', import.meta.url)
-    .pathname
-  const fastify = createFastify()
-  fastify.register(createServer, { filepath, lazy: true })
-  await fastify.listen()
-  assert.equal(await fdCount(filepath), 0)
-  await fastify.inject({ url: '/style.json' })
-  assert.equal(await fdCount(filepath), 1)
-  await fastify.close()
-  assert.equal(await fdCount(filepath), 0)
-})
-
 test('server invalid filepath', async (t) => {
   const filepath = 'invalid_file_path'
   const fastify = createFastify()


### PR DESCRIPTION
BREAKING: server will always try to read / pre-cache file entries on startup.

This is prep for #27, because `lazy` does not have a use-case yet, and it adds additional complexity.