### PR TITLE
chore: update server plugin documentation

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -35,7 +35,9 @@ function sendResource(reply, resource) {
 }
 
 /**
- * Fastify plugin for serving a styled map package. If you provide a `Reader` (or `ReaderWatch`) instance via the `reader` opt,
+ * Fastify plugin for serving a styled map package.
+ *
+ * If you provide a `Reader` (or `ReaderWatch`) instance via the `reader` opt,
  * you must manually close the instance yourself.
  *
  * @type {FastifyPluginCallback<PluginOptions>}

--- a/lib/server.js
+++ b/lib/server.js
@@ -35,8 +35,8 @@ function sendResource(reply, resource) {
 }
 
 /**
- * Fastify plugin for serving a styled map package. User `lazy: true` to defer
- * opening the file until the first request.
+ * Fastify plugin for serving a styled map package. If you provide a `Reader` (or `ReaderWatch`) instance via the `reader` opt,
+ * you must manually close the instance yourself.
  *
  * @type {FastifyPluginCallback<PluginOptions>}
  */


### PR DESCRIPTION
Purely a documentation change for the server plugin.

- Removes the reference to the `lazy` option, which has been removed.
- Notes the need to close to instance provided to the `reader` opt manually.