### PR TITLE
feat: optimize order of entries

### DIFF
--- a/lib/utils/templates.js
+++ b/lib/utils/templates.js
@@ -3,9 +3,9 @@ export const URI_BASE = URI_SCHEME + '://maps.v1/'
 
 // These constants determine the file format structure
 export const STYLE_FILE = 'style.json'
-const SOURCES_FOLDER = 's'
+export const SOURCES_FOLDER = 's'
 const SPRITES_FOLDER = 'sprites'
-const FONTS_FOLDER = 'fonts'
+export const FONTS_FOLDER = 'fonts'
 
 // This must include placeholders `{z}`, `{x}`, `{y}`, since these are used to
 // define the tile URL, and this is a TileJSON standard.

--- a/lib/writer.js
+++ b/lib/writer.js
@@ -14,12 +14,14 @@ import { clone } from './utils/misc.js'
 import { writeStreamFromAsync } from './utils/streams.js'
 import { replaceFontStacks } from './utils/style.js'
 import {
+  FONTS_FOLDER,
   getGlyphFilename,
   getSpriteFilename,
   getSpriteUri,
   getTileFilename,
   getTileUri,
   GLYPH_URI,
+  SOURCES_FOLDER,
   STYLE_FILE,
 } from './utils/templates.js'
 
@@ -338,11 +340,12 @@ export default class Writer extends EventEmitter {
    * This method must be called to complete the archive.
    * You must wait for your destination write stream to 'finish' before using the output.
    */
-  finish() {
+  async finish() {
     this.#prepareStyle()
     const style = JSON.stringify(this.#style)
-    this.#append(style, { name: STYLE_FILE })
-    this.#archive.finalize()
+    await this.#append(style, { name: STYLE_FILE })
+    sortEntries(this.#archive)
+    await this.#archive.finalize()
   }
 
   /**
@@ -475,4 +478,73 @@ function isEmptyFeatureCollection(data) {
 function get2DBBox(bbox) {
   if (bbox.length === 4) return bbox
   return [bbox[0], bbox[1], bbox[3], bbox[4]]
+}
+
+/**
+ * @typedef {object} ZipEntry
+ * @property {string} name
+ */
+
+/**
+ * Dive into the internals of Archiver to sort the central directory entries of
+ * the zip, so that the style.json, ASCII glyphs, and initial tiles are listed
+ * first, which improves read speed (the map can be displayed before the entire
+ * central directory is indexed)
+ * @param {import('archiver').Archiver} archive
+ */
+function sortEntries(archive) {
+  // @ts-expect-error
+  const entries = /** @type {unknown} */ (archive._module?.engine?._entries)
+  if (!Array.isArray(entries)) {
+    throw new Error(
+      'Cannot find zip entries: check implementation changes in Archiver',
+    )
+  }
+  const sortedEntries = entries.sort(
+    /**
+     * @param {unknown} a
+     * @param {unknown} b
+     */
+    function (a, b) {
+      assertValidEntry(a)
+      assertValidEntry(b)
+      if (a.name === 'style.json') return -1
+      if (b.name === 'style.json') return 1
+      const foldersA = a.name.split('/')
+      const foldersB = b.name.split('/')
+      if (foldersA[0] === FONTS_FOLDER && foldersA[2] === '0-255.pbf.gz')
+        return -1
+      if (foldersB[0] === FONTS_FOLDER && foldersB[2] === '0-255.pbf.gz')
+        return 1
+      if (foldersA[0] === SOURCES_FOLDER && foldersB[0] !== SOURCES_FOLDER)
+        return -1
+      if (foldersB[0] === SOURCES_FOLDER && foldersA[0] !== SOURCES_FOLDER)
+        return 1
+      if (foldersA[0] === SOURCES_FOLDER && foldersB[0] === SOURCES_FOLDER) {
+        const zoomA = +foldersA[2]
+        const zoomB = +foldersB[2]
+        return zoomA - zoomB
+      }
+      return 0
+    },
+  )
+  // @ts-expect-error
+  archive._module.engine._entries = sortedEntries
+}
+
+/**
+ * @param {unknown} maybeEntry
+ * @returns {asserts maybeEntry is ZipEntry}
+ */
+function assertValidEntry(maybeEntry) {
+  if (
+    !maybeEntry ||
+    typeof maybeEntry !== 'object' ||
+    !('name' in maybeEntry) ||
+    typeof maybeEntry.name !== 'string'
+  ) {
+    throw new Error(
+      'Unexpected zip entry type: check implementation changes in Archiver',
+    )
+  }
 }

--- a/test/fixtures/valid-styles/all-types.input.json
+++ b/test/fixtures/valid-styles/all-types.input.json
@@ -1,0 +1,25 @@
+{
+  "version": 8,
+  "name": "Example (fake)",
+  "sources": {
+    "source1": {
+      "type": "vector",
+      "url": "https://example.com/source1.json"
+    },
+    "source2": {
+      "type": "vector",
+      "url": "https://example.com/source2.json"
+    }
+  },
+  "glyph": "https://example.com/font/{fontstack}/{range}.pbf",
+  "sprite": "https://example.com/sprite",
+  "layers": [
+    {
+      "id": "background",
+      "type": "background",
+      "paint": {
+        "background-color": "#f8f4f0"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This reaches into some internals of Archiver and its dependency Zip Stream in order to sort the entries that are written to the zip central directory record. By default Archiver writes the directory entries in the same order as the files are written to the zip, but this is not necessary per the zip spec. When reading a styled map package, resources like style.json can be read as soon as their directory entry is read, so putting the style.json first speeds up the initial appearance of a map when viewing an SMP.