### PR TITLE
chore!: API cleanup & readme improvements

### DIFF
--- a/.changeset/polite-cobras-float.md
+++ b/.changeset/polite-cobras-float.md
@@ -1,0 +1,6 @@
+---
+'styled-map-package-api': major
+'styled-map-package': major
+---
+
+API cleanup for consistency: accessToken -> mapboxAccessToken and download now cleans up resources on cancel.

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ A Styled Map Package (`.smp`) file is a Zip archive containing all the resources
 
 ## Packages
 
-This monorepo contains two packages:
-
 | Package                                   | Description                                                   |
 | ----------------------------------------- | ------------------------------------------------------------- |
 | [`styled-map-package`](packages/cli/)     | CLI for creating, viewing, and converting `.smp` files        |
 | [`styled-map-package-api`](packages/api/) | JavaScript API for reading, writing, and serving `.smp` files |
+| [`smp-noto-glyphs`](packages/glyphs/)     | Pre-built Noto Sans SDF glyph fallbacks for 80+ scripts       |
+
+The [SMP 1.0 specification](spec/1.0/) defines the `.smp` file format.
 
 ## Quick start
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -19,28 +19,72 @@ import { Reader } from 'styled-map-package-api/reader'
 
 const reader = new Reader('path/to/map.smp')
 const style = await reader.getStyle()
+// Close the underlying file descriptor when done to free system resources
+await reader.close()
 ```
+
+The `Reader` constructor accepts a file path (Node.js) or a `ZipReader` instance (browser), and an optional options object:
+
+- **`maxEntries`** — maximum number of ZIP entries to process (default: 500,000). Exceeding this limit throws an error to avoid DoS attacks with maliciously crafted ZIP files containing excessive entries.
+- **`maxResourceSize`** — maximum uncompressed size in bytes for a single resource (default: 20 MiB). Exceeding this limit throws an error to prevent excessive memory usage.
+
+If you pass a file path to the `Reader` constructor, it will keep the file open until you call `reader.close()`.
 
 ### Writing an SMP file
 
 ```js
 import { Writer } from 'styled-map-package-api/writer'
 
-const writer = new Writer(style, sources)
+const writer = new Writer(style, { dedupe: true })
 const stream = writer.outputStream
 // Pipe stream to a file or other writable destination
+
+await writer.addTile(tileData, { z: 0, x: 0, y: 0, sourceId: 'my-source' })
+await writer.addSprite({ json: spriteJson, png: spritePng })
+await writer.addGlyphs(glyphData, { font: 'Noto Sans', range: '0-255' })
+
 await writer.finish()
 ```
 
+The `Writer` constructor takes a [MapLibre style](https://maplibre.org/maplibre-style-spec/) object and an optional options object:
+
+- **`dedupe`** — when `true`, duplicate tiles (with identical content) are stored only once, reducing file size for tilesets with many repeated tiles (e.g. ocean tiles).
+
+  > **Warning:** This deduplication technique causes a mismatch between the filename stored in the local file header and the filename in the aliased central directory entries. While the ZIP specification does not forbid this, many general-purpose ZIP tools do not handle it correctly. macOS Finder fails to expand such archives, Info-ZIP `unzip` emits warnings, and strict readers such as `yauzl` (Node.js) and Go's `archive/zip` may reject the entries. Writers that need the resulting archive to be compatible with general-purpose ZIP tools SHOULD NOT use this technique.
+
+Sources are added implicitly when tiles are added via `addTile()`. Use `createTileWriteStream()` and `createGlyphWriteStream()` for concurrent writes.
+
 ### Serving over HTTP
 
+`createServer()` returns a `{ fetch }` object, where `fetch(request, reader)` is a handler that takes a [WHATWG `Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) and a `Reader` instance. On success it returns a [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response). On failure it **throws** a `StatusError` (from `itty-router`) rather than returning an error response — this lets you decide how to respond to errors in your application.
+
+A `StatusError` has a numeric `status` property (e.g. `404`) and a `message` string, so you can serialize it however you like:
+
 ```js
+import { createServerAdapter } from '@whatwg-node/server'
 import { Reader } from 'styled-map-package-api/reader'
 import { createServer } from 'styled-map-package-api/server'
 
+import { createServer as createHTTPServer } from 'node:http'
+
 const reader = new Reader('path/to/map.smp')
-const server = createServer()
-// server.fetch(request, reader) returns a WHATWG Response
+const smpServer = createServer()
+
+const httpServer = createHTTPServer(
+  createServerAdapter(async (request) => {
+    try {
+      return await smpServer.fetch(request, reader)
+    } catch (err) {
+      const status = err.status || 500
+      return new Response(JSON.stringify({ error: err.message, status }), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+  }),
+)
+
+httpServer.listen(3000)
 ```
 
 ### Fallback tiles and glyphs
@@ -99,16 +143,42 @@ const stream = download({
   styleUrl: 'https://demotiles.maplibre.org/style.json',
   bbox: [-180, -80, 180, 80],
   maxzoom: 5,
-  skipLocalGlyphs: true, // skip CJK/Hangul/Kana ranges rendered locally by MapLibre
+  skipLocalGlyphs: true,
+  onprogress: (progress) => console.log(progress),
 })
 // Pipe the ReadableStream to a file
 ```
 
+**Options:**
+
+| Option              | Type        | Description                                                            |
+| ------------------- | ----------- | ---------------------------------------------------------------------- |
+| `styleUrl`          | `string`    | URL of the map style to download (required)                            |
+| `bbox`              | `BBox`      | Bounding box `[west, south, east, north]` for tile download (required) |
+| `maxzoom`           | `number`    | Maximum zoom level to download (required)                              |
+| `mapboxAccessToken` | `string?`   | Mapbox access token (required for Mapbox styles)                       |
+| `skipLocalGlyphs`   | `boolean?`  | Skip CJK/Hangul/Kana glyph ranges rendered client-side by MapLibre GL  |
+| `dedupe`            | `boolean?`  | Store duplicate tiles only once to reduce file size                    |
+| `onprogress`        | `function?` | Callback receiving a `DownloadProgress` object (see below)             |
+
 The `skipLocalGlyphs` option skips downloading glyph ranges that MapLibre GL renders client-side via [`localIdeographFontFamily`](https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/MapOptions/) (CJK, Hangul, Kana, Yi, and Halfwidth/Fullwidth Forms — 163 of 256 ranges). This significantly reduces download size for styles that use these scripts.
+
+The `onprogress` callback receives a `DownloadProgress` object:
+
+```js
+{
+  tiles:   { downloaded, totalBytes, total, skipped, done },
+  style:   { done },
+  sprites: { downloaded, done },
+  glyphs:  { downloaded, total, totalBytes, done },
+  output:  { totalBytes, done },
+  elapsedMs: number,
+}
+```
 
 ### Converting from MBTiles
 
-> **Note:** MBTiles conversion requires Node >= 20 (uses `better-sqlite3` which dropped Node 18 support).
+> **Note:** MBTiles conversion requires Node >= 20 (uses `better-sqlite3` which dropped Node 18 support). Only raster MBTiles are currently supported — vector MBTiles will throw an error.
 
 ```js
 import { fromMBTiles } from 'styled-map-package-api/from-mbtiles'

--- a/packages/api/lib/download.js
+++ b/packages/api/lib/download.js
@@ -1,4 +1,5 @@
 import { StyleDownloader } from './style-downloader.js'
+import { noop } from './utils/misc.js'
 import { readableFromAsync } from './utils/streams.js'
 import { Writer } from './writer.js'
 
@@ -22,9 +23,10 @@ import { Writer } from './writer.js'
  * @param {number} opts.maxzoom Max zoom level to download tiles for
  * @param {string} opts.styleUrl URL of the style to download
  * @param { (progress: DownloadProgress) => void } [opts.onprogress] Optional callback for reporting progress
- * @param {string} [opts.accessToken]
+ * @param {string} [opts.mapboxAccessToken]
  * @param {boolean} [opts.skipLocalGlyphs] Skip glyph ranges rendered client-side by MapLibre GL via localIdeographFontFamily (CJK, Hangul, Kana, Yi, etc.)
  * @param {boolean} [opts.dedupe] When true, duplicate tiles are stored only once (see {@link Writer})
+ * @param {AbortSignal} [opts.signal] AbortSignal to cancel the download
  * @returns {import('./types.js').DownloadStream} Readable stream of the output styled map file
  */
 export function download({
@@ -32,14 +34,19 @@ export function download({
   maxzoom,
   styleUrl,
   onprogress,
-  accessToken,
+  mapboxAccessToken,
   skipLocalGlyphs,
   dedupe,
+  signal: signalExt,
 }) {
-  const downloader = new StyleDownloader(styleUrl, {
-    concurrency: 24,
-    mapboxAccessToken: accessToken,
-  })
+  /** @type {ReadableStreamDefaultReader<Uint8Array> | undefined} */
+  let outputReader
+  /** @type {Promise<void> | undefined} */
+  let downloadDone
+  const pipeAbort = new AbortController()
+  const signal = signalExt
+    ? AbortSignal.any([signalExt, pipeAbort.signal])
+    : pipeAbort.signal
 
   let start = Date.now()
   /** @type {DownloadProgress} */
@@ -58,68 +65,97 @@ export function download({
     onprogress?.(progress)
   }
 
-  const sizeCounter = new TransformStream({
-    transform(chunk, controller) {
-      handleProgress({
-        output: {
-          totalBytes: progress.output.totalBytes + chunk.byteLength,
-          done: false,
-        },
+  return new ReadableStream({
+    async start() {
+      if (signal?.aborted) {
+        throw (
+          signal.reason ||
+          new DOMException('The operation was aborted.', 'AbortError')
+        )
+      }
+
+      const downloader = new StyleDownloader(styleUrl, {
+        concurrency: 24,
+        mapboxAccessToken,
       })
-      controller.enqueue(chunk)
+
+      const style = await downloader.getStyle()
+      handleProgress({ style: { done: true } })
+
+      const writer = new Writer(style, { dedupe: !!dedupe })
+      outputReader = writer.outputStream.getReader()
+
+      downloadDone = (async () => {
+        try {
+          for await (const spriteInfo of downloader.getSprites()) {
+            await writer.addSprite(spriteInfo)
+            handleProgress({
+              sprites: {
+                downloaded: progress.sprites.downloaded + 1,
+                done: false,
+              },
+            })
+          }
+          handleProgress({ sprites: { ...progress.sprites, done: true } })
+
+          const tiles = downloader.getTiles({
+            bounds: bbox,
+            maxzoom,
+            onprogress: (tileStats) =>
+              handleProgress({ tiles: { ...tileStats, done: false } }),
+          })
+          await readableFromAsync(tiles).pipeTo(
+            writer.createTileWriteStream({ concurrency: 24 }),
+            { signal },
+          )
+          handleProgress({ tiles: { ...progress.tiles, done: true } })
+
+          const glyphs = downloader.getGlyphs({
+            skipLocalGlyphs,
+            onprogress: (glyphStats) =>
+              handleProgress({ glyphs: { ...glyphStats, done: false } }),
+          })
+          await readableFromAsync(glyphs).pipeTo(
+            writer.createGlyphWriteStream(),
+            { signal },
+          )
+          handleProgress({ glyphs: { ...progress.glyphs, done: true } })
+
+          await writer.finish()
+        } catch (err) {
+          try {
+            writer.abort(err instanceof Error ? err : new Error(String(err)))
+          } catch {
+            // Output stream may already be cancelled/errored
+          }
+        }
+      })()
     },
-    flush() {
-      handleProgress({ output: { ...progress.output, done: true } })
+    async pull(controller) {
+      if (!outputReader) {
+        controller.error(
+          new Error('Output reader not initialized. This is a bug.'),
+        )
+        return
+      }
+      const { done, value } = await outputReader.read()
+      if (done) {
+        controller.close()
+        handleProgress({ output: { ...progress.output, done: true } })
+      } else {
+        handleProgress({
+          output: {
+            totalBytes: progress.output.totalBytes + value.byteLength,
+            done: false,
+          },
+        })
+        controller.enqueue(value)
+      }
+    },
+    async cancel(reason) {
+      pipeAbort.abort(reason)
+      await downloadDone
+      await outputReader?.cancel(reason).catch(noop)
     },
   })
-
-  ;(async () => {
-    /** @type {Writer | undefined} */
-    let writer
-    try {
-      const style = await downloader.getStyle()
-      writer = new Writer(style, { dedupe: !!dedupe })
-      handleProgress({ style: { done: true } })
-      // Pipe the output stream through the size counter (fire-and-forget;
-      // errors propagate via writer.abort())
-      writer.outputStream.pipeTo(sizeCounter.writable).catch(() => {})
-
-      for await (const spriteInfo of downloader.getSprites()) {
-        await writer.addSprite(spriteInfo)
-        handleProgress({
-          sprites: { downloaded: progress.sprites.downloaded + 1, done: false },
-        })
-      }
-      handleProgress({ sprites: { ...progress.sprites, done: true } })
-
-      const tiles = downloader.getTiles({
-        bounds: bbox,
-        maxzoom,
-        onprogress: (tileStats) =>
-          handleProgress({ tiles: { ...tileStats, done: false } }),
-      })
-      await readableFromAsync(tiles).pipeTo(
-        writer.createTileWriteStream({ concurrency: 24 }),
-      )
-      handleProgress({ tiles: { ...progress.tiles, done: true } })
-
-      const glyphs = downloader.getGlyphs({
-        skipLocalGlyphs,
-        onprogress: (glyphStats) =>
-          handleProgress({ glyphs: { ...glyphStats, done: false } }),
-      })
-      await readableFromAsync(glyphs).pipeTo(writer.createGlyphWriteStream())
-      handleProgress({ glyphs: { ...progress.glyphs, done: true } })
-
-      writer.finish()
-    } catch (err) {
-      if (writer) {
-        writer.abort(/** @type {Error} */ (err))
-      } else {
-        sizeCounter.writable.abort(/** @type {Error} */ (err))
-      }
-    }
-  })()
-
-  return sizeCounter.readable
 }

--- a/packages/api/lib/from-mbtiles.js
+++ b/packages/api/lib/from-mbtiles.js
@@ -88,7 +88,7 @@ export function fromMBTiles(source) {
             writer.createTileWriteStream(),
             { signal: pipeAbort.signal },
           )
-          writer.finish()
+          await writer.finish()
         } catch (err) {
           try {
             writer.abort(err instanceof Error ? err : new Error(String(err)))

--- a/packages/api/lib/reader.js
+++ b/packages/api/lib/reader.js
@@ -188,7 +188,7 @@ export class Reader {
   #maxResourceSize
 
   /**
-   * @param {string | import('@gmaclennan/zip-reader').ZipReader} filepathOrZip Path to styled map package (`.styledmap`) file, or a ZipReader instance
+   * @param {string | import('@gmaclennan/zip-reader').ZipReader} filepathOrZip Path to styled map package (`.smp`) file, or a ZipReader instance
    * @param {ReaderOptions} [options]
    */
   constructor(filepathOrZip, options = {}) {

--- a/packages/api/lib/server.js
+++ b/packages/api/lib/server.js
@@ -48,7 +48,6 @@ function json(obj) {
  * @example
  * ```js
  * import { createServer } from 'node:http'
- * import { error } from 'itty-router/error'
  * import { createServerAdapter } from '@whatwg-node/server'
  * import { createServer as createSMPServer } from 'styled-map-package-api/server'
  * import { Reader } from 'styled-map-package-api/reader'
@@ -56,7 +55,7 @@ function json(obj) {
  * const reader = new Reader('path/to/your-style.smp')
  * const smpServer = createSMPServer()
  * const httpServer = createServer(createServerAdapter((request) => {
- *   return smpServer.fetch(request, reader).catch(error)
+ *   return smpServer.fetch(request, reader)
  * }))
  * ```
  *
@@ -148,7 +147,7 @@ export function createServer({ base = '/', fallbackTile, fallbackGlyph } = {}) {
       }
     })
   return {
-    fetch: (request, reader) => {
+    fetch: async (request, reader) => {
       return router.fetch(request, reader).catch((err) => {
         if (isFileNotThereError(err)) {
           throw new StatusError(404, 'Not Found')

--- a/packages/api/lib/writer.js
+++ b/packages/api/lib/writer.js
@@ -64,8 +64,8 @@ export const SUPPORTED_SOURCE_TYPES = /** @type {const} */ ([
 
 /**
  * Write a styled map package to a stream. Stream `writer.outputStream` to a
- * destination, e.g. `fs.createWriteStream('my-map.styledmap')`. You must call
- * `witer.finish()` and then wait for your writable stream to `finish` before
+ * destination, e.g. `fs.createWriteStream('my-map.smp')`. You must call
+ * `writer.finish()` and then wait for your writable stream to `finish` before
  * using the output.
  */
 export class Writer {
@@ -90,8 +90,6 @@ export class Writer {
   #tileHashes = new Map()
   /** @type {Array<{ name: string, originalName: string }>} */
   #duplicateEntries = []
-
-  static SUPPORTED_SOURCE_TYPES = SUPPORTED_SOURCE_TYPES
 
   /**
    * @param {any} style A v7 or v8 MapLibre style. v7 styles will be migrated to
@@ -376,7 +374,7 @@ export class Writer {
    * @param {GlyphInfo} glyphInfo
    * @returns {Promise<void>}
    */
-  addGlyphs(glyphData, { font: fontName, range }) {
+  async addGlyphs(glyphData, { font: fontName, range }) {
     this.#fonts.add(fontName)
     const name = getGlyphFilename({ fontstack: fontName, range })
     return this.#append(glyphData, { name })

--- a/packages/api/test/download.js
+++ b/packages/api/test/download.js
@@ -140,6 +140,61 @@ describe('download with demotiles-z2 (glyphs, no sprites)', () => {
       await expect(() => streamToBuffer(smpStream)).rejects.toThrow()
     },
   )
+
+  test('download rejects immediately when signal is already aborted', async () => {
+    const smpStream = download({
+      styleUrl: server.baseUrl + 'style.json',
+      bbox: [-180, -85, 180, 85],
+      maxzoom: 0,
+      signal: AbortSignal.abort('already cancelled'),
+    })
+
+    await expect(() => streamToBuffer(smpStream)).rejects.toThrow(
+      'already cancelled',
+    )
+  })
+
+  test('download can be cancelled with AbortSignal', async () => {
+    const ac = new AbortController()
+    /** @type {import('../lib/download.js').DownloadProgress[]} */
+    const progressUpdates = []
+    const smpStream = download({
+      styleUrl: server.baseUrl + 'style.json',
+      bbox: [-180, -85, 180, 85],
+      maxzoom: 2,
+      signal: ac.signal,
+      onprogress: (p) => {
+        progressUpdates.push(structuredClone(p))
+        // Abort after the style is downloaded but before everything completes
+        if (p.style.done) ac.abort()
+      },
+    })
+
+    await expect(() => streamToBuffer(smpStream)).rejects.toThrow()
+
+    // Should have received some progress before cancellation
+    assert(progressUpdates.length > 0, 'received progress updates')
+    assert.equal(
+      progressUpdates[progressUpdates.length - 1].style.done,
+      true,
+      'style was downloaded before abort',
+    )
+  })
+
+  test('download stream can be cancelled via reader.cancel()', async () => {
+    const smpStream = download({
+      styleUrl: server.baseUrl + 'style.json',
+      bbox: [-180, -85, 180, 85],
+      maxzoom: 2,
+    })
+
+    const reader = smpStream.getReader()
+    // Read one chunk then cancel
+    const { done } = await reader.read()
+    assert.equal(done, false, 'first read returns data')
+    await reader.cancel('no longer needed')
+    // Should not throw or hang — cancel cleans up gracefully
+  })
 })
 
 describe('download with osm-bright-z6 (sprites)', () => {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -46,11 +46,11 @@ smp view demotiles.smp --open
 
 **Options:**
 
-| Option                | Description                                                       |
-| --------------------- | ----------------------------------------------------------------- |
-| `-o, --open`          | Open in the default web browser                                   |
-| `-p, --port <number>` | Port to serve on (default: 3000)                                  |
-| `-f, --fallback`      | Serve empty tiles and glyphs for missing resources instead of 404 |
+| Option                | Description                                                                 |
+| --------------------- | --------------------------------------------------------------------------- |
+| `-o, --open`          | Open in the default web browser                                             |
+| `-p, --port <number>` | Port to serve on (default: 3000)                                            |
+| `-f, --fallback`      | Serve empty tiles and Noto Sans glyphs for missing resources instead of 404 |
 
 The `--fallback` flag is useful for previewing SMP files that don't contain every tile or glyph range referenced by the style. Missing vector tiles are served as empty MVTs, missing raster tiles as transparent pixels. Missing glyph ranges are served using bundled [Noto Sans](https://fonts.google.com/noto/specimen/Noto+Sans) glyphs (via [GoNotoKurrent](https://github.com/satbyy/go-noto-universal), covering 80+ scripts including Latin, Cyrillic, Greek, Arabic, Hebrew, Devanagari, Thai, and more). CJK and Hangul ranges are not bundled since MapLibre renders these client-side via `localIdeographFontFamily`.
 

--- a/packages/cli/lib/commands/download.js
+++ b/packages/cli/lib/commands/download.js
@@ -178,7 +178,7 @@ export async function runDownload(
     maxzoom: zoom,
     styleUrl,
     onprogress: (/** @type {any} */ p) => reporter.write(p),
-    accessToken: token,
+    mapboxAccessToken: token,
     skipLocalGlyphs,
     dedupe,
   })

--- a/packages/cli/test/commands/download.js
+++ b/packages/cli/test/commands/download.js
@@ -230,7 +230,7 @@ describe('runDownload', () => {
       expect.objectContaining({ message: 'Mapbox access token' }),
     )
     expect(deps.download).toHaveBeenCalledWith(
-      expect.objectContaining({ accessToken: 'pk.test-token' }),
+      expect.objectContaining({ mapboxAccessToken: 'pk.test-token' }),
     )
   })
 
@@ -250,7 +250,7 @@ describe('runDownload', () => {
 
     expect(deps.prompt.input).not.toHaveBeenCalled()
     expect(deps.download).toHaveBeenCalledWith(
-      expect.objectContaining({ accessToken: 'pk.existing-token' }),
+      expect.objectContaining({ mapboxAccessToken: 'pk.existing-token' }),
     )
   })
 


### PR DESCRIPTION
1. docs: fix README inaccuracies and improve API documentation
2. feat: download now accepts an abortSignal
3. fix: download propagates errors and cleans up resources on cancel
4. refactor!: rename accessToken -> mapboxAccessToken
5. test: download cancellation tests