### PR TITLE
feat: document and display map source attribution

### DIFF
--- a/.changeset/tidy-maps-credit.md
+++ b/.changeset/tidy-maps-credit.md
@@ -1,0 +1,6 @@
+---
+'styled-map-package-api': patch
+'styled-map-package': patch
+---
+
+Document map source `attribution` in the format spec (Section 5.7) and display a compact attribution control in `smp view`. Source `attribution` — including credits inlined from TileJSON and MBTiles metadata — is preserved through write/read, and the map viewer now renders it.

--- a/packages/api/lib/writer.js
+++ b/packages/api/lib/writer.js
@@ -231,6 +231,8 @@ export class Writer {
       case 'raster':
       case 'vector':
         smpSource = {
+          // Only tile-addressing keys are dropped; `attribution` and other
+          // source properties are intentionally retained (spec §5.7).
           ...excludeKeys(source, ['tiles', 'url', 'scheme']),
           scheme: 'xyz',
           ...tileSourceOverrides,

--- a/packages/api/test/write-read.js
+++ b/packages/api/test/write-read.js
@@ -644,6 +644,86 @@ test('Raster tiles write and read', async () => {
   expect(jpgTileHashOut, 'JPG tile is the same').toBe(jpgTileHash)
 })
 
+test('Source attribution is preserved through write & read', async () => {
+  const vectorAttribution = '© <a href="https://example.com">Example Vector</a>'
+  const rasterAttribution = 'Imagery © Example Raster'
+  const geojsonAttribution = 'Data © Example GeoJSON'
+
+  /** @type {import('@maplibre/maplibre-gl-style-spec').StyleSpecification} */
+  const styleIn = {
+    version: 8,
+    name: 'Attribution test',
+    sources: {
+      vector: {
+        type: 'vector',
+        tiles: ['https://example.com/v/{z}/{x}/{y}.mvt'],
+        attribution: vectorAttribution,
+      },
+      raster: {
+        type: 'raster',
+        tiles: ['https://example.com/r/{z}/{x}/{y}.png'],
+        tileSize: 256,
+        attribution: rasterAttribution,
+      },
+      geojson: {
+        type: 'geojson',
+        data: {
+          type: 'FeatureCollection',
+          features: [
+            {
+              type: 'Feature',
+              properties: {},
+              geometry: { type: 'Point', coordinates: [0, 0] },
+            },
+          ],
+        },
+        attribution: geojsonAttribution,
+      },
+    },
+    layers: [
+      { id: 'bg', type: 'background', paint: { 'background-color': '#fff' } },
+      { id: 'vector', type: 'line', source: 'vector', 'source-layer': 'l' },
+      { id: 'raster', type: 'raster', source: 'raster' },
+      { id: 'geojson', type: 'circle', source: 'geojson' },
+    ],
+  }
+
+  const writer = new Writer(styleIn)
+  const smpPromise = streamToBuffer(writer.outputStream)
+  await writer.addTile(randomWebStream({ size: 1024 }), {
+    x: 0,
+    y: 0,
+    z: 0,
+    sourceId: 'vector',
+    format: 'mvt',
+  })
+  await writer.addTile(randomWebStream({ size: 1024 }), {
+    x: 0,
+    y: 0,
+    z: 0,
+    sourceId: 'raster',
+    format: 'png',
+  })
+  writer.finish()
+
+  const smp = await smpPromise
+  const reader = new Reader(await ZipReader.from(new BufferSource(smp)))
+  const styleOut = await reader.getStyle()
+
+  expect(
+    /** @type {any} */ (styleOut.sources.vector).attribution,
+    'vector source attribution preserved',
+  ).toBe(vectorAttribution)
+  expect(
+    /** @type {any} */ (styleOut.sources.raster).attribution,
+    'raster source attribution preserved',
+  ).toBe(rasterAttribution)
+  expect(
+    /** @type {any} */ (styleOut.sources.geojson).attribution,
+    'geojson source attribution preserved',
+  ).toBe(geojsonAttribution)
+})
+
 test('Optimized central directory order', async () => {
   const styleInUrl = new URL(
     './fixtures/valid-styles/all-types.input.json',

--- a/packages/cli/map-viewer/index.html
+++ b/packages/cli/map-viewer/index.html
@@ -32,6 +32,7 @@
       const map = new maplibregl.Map({
         container: 'map',
         style: 'map/style.json',
+        attributionControl: { compact: true },
       })
 
       map.on('error', (e) => {

--- a/spec/1.0/README.md
+++ b/spec/1.0/README.md
@@ -240,7 +240,7 @@ Vector tiles (`.mvt`, `.pbf`) SHOULD be stored gzip-compressed (using the `.mvt.
 
 Files with a `.mvt` or `.pbf` extension (without `.gz`) MUST NOT contain gzip-compressed data. Only the `.mvt.gz` and `.pbf.gz` extensions indicate gzip compression.
 
-Tiles with no meaningful content (e.g. ocean tiles) are still valid and MUST be present if they fall within the source's bounds and zoom range (see [Section 5.7](#57-tile-bounds-and-completeness)). An "empty" vector tile still contains valid protobuf headers, and an "empty" raster tile is a valid image file (e.g. a single-color PNG). The central directory deduplication technique described in [Section 3.6](#36-central-directory) can be used to store identical tiles efficiently without duplicating their data.
+Tiles with no meaningful content (e.g. ocean tiles) are still valid and MUST be present if they fall within the source's bounds and zoom range (see [Section 5.8](#58-tile-bounds-and-completeness)). An "empty" vector tile still contains valid protobuf headers, and an "empty" raster tile is a valid image file (e.g. a single-color PNG). The central directory deduplication technique described in [Section 3.6](#36-central-directory) can be used to store identical tiles efficiently without duplicating their data.
 
 ### 5.3 Tile Format Consistency
 
@@ -279,7 +279,15 @@ Each tile source in `style.json` MUST include:
 
 Tile sources MUST NOT include a `url` property. If the original style references a [TileJSON](https://github.com/mapbox/tilejson-spec) endpoint via `url`, the relevant TileJSON properties (`bounds`, `minzoom`, `maxzoom`, `tiles`) MUST be inlined directly in the source object and the `url` property MUST be removed.
 
-### 5.7 Tile Bounds and Completeness
+### 5.7 Source Attribution
+
+A tile source MAY include an `attribution` property, as defined by the [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/sources/). Its value is a plain-text or HTML string crediting the data provider. It does not reference any resource inside the archive, so the SMP URI requirements of [Section 4.2](#42-smp-uri-scheme) do not apply to it.
+
+Writers SHOULD preserve a source's `attribution` property in the output `style.json`. When a source is derived from a [TileJSON](https://github.com/mapbox/tilejson-spec) endpoint, writers SHOULD inline the TileJSON `attribution` value into the source object (see [Section 5.6](#56-source-properties)).
+
+Readers and serving implementations MUST return the `attribution` property unmodified when it is present in `style.json`, so that mapping libraries can display correct data credits for offline maps.
+
+### 5.8 Tile Bounds and Completeness
 
 The `bounds` property of a tile source MUST reflect the geographic extent of available tile data, as defined by the [TileJSON specification](https://github.com/mapbox/tilejson-spec). It represents the bounding box within which tile data is present and MAY be used by clients to limit requests to this region.
 


### PR DESCRIPTION
Add spec section 5.7 covering source `attribution`: writers SHOULD preserve it, readers/servers MUST return it unmodified. Display a compact attribution control in `smp view`, and add a write/read test covering attribution round-trip for vector, raster and geojson sources.