### PR TITLE
feat: configurable tile buffer, fix viewing/serving buffer

### DIFF
--- a/.changeset/buffer-bounds-metadata.md
+++ b/.changeset/buffer-bounds-metadata.md
@@ -1,0 +1,14 @@
+---
+'styled-map-package-api': minor
+'styled-map-package': minor
+---
+
+Optionally add a tile buffer to improve offline viewing.
+
+Buffer tiles are extra tile rings downloaded around the requested area at each zoom level below maxzoom, so the map is not clipped at the edges of the downloaded area when zooming out. The buffer is not applied at maxzoom, where it would add disk overhead without improving viewport coverage.
+
+- Adds a `bufferTiles` option (a non-negative integer ring count, default `0`) to `download()`, `StyleDownloader#getTiles`, `downloadTiles`, `downloadPmtilesTiles`, and `tileIterator`. Replaces the previous boolean `boundsBuffer`. Exposed on the CLI as the boolean flag `smp download --buffer-tiles` (one ring).
+- Records the buffer in the style metadata as `smp:bufferTiles` (new spec §4.3.4). The `Writer` infers this value from the tiles it receives — the number of extra tile rings that extend beyond the max-zoom `bounds`.
+- Adds an `expandBounds` option to `createServer`, enabled by default. When the package has `smp:bufferTiles` metadata, each tile source's `bounds` is widened to the whole world in the served `style.json` (the stored file is unchanged), so the lower-zoom buffer tiles are rendered. Combined with the default empty-tile fallback, this serves empty tiles outside the downloaded area. Pass `expandBounds: false` to disable.
+- `createServer` now defaults `fallbackTile`/`fallbackGlyph` to the built-in empty fallbacks, so a plain `createServer()` serves empty tiles/glyphs for missing resources instead of returning 404. Pass `null` for either option to restore 404 behavior.
+- `smp view` now enables `expandBounds` and serves empty-tile/glyph fallbacks by default. The previous `-f, --fallback` flag is replaced by `--no-fallback` to opt out.

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -89,33 +89,31 @@ httpServer.listen(3000)
 
 ### Fallback tiles and glyphs
 
-When an SMP file doesn't contain every tile or glyph range that the style references, `createServer` can call fallback handlers instead of returning a 404. This is useful for previewing incomplete packages or packages that only cover a partial area/zoom range.
+When an SMP file doesn't contain every tile or glyph range that the style references, `createServer` calls fallback handlers instead of returning a 404. This is useful for previewing incomplete packages or packages that only cover a partial area/zoom range.
 
-Built-in fallback handlers are provided:
+By default `fallbackTile` is `emptyTileFallback` and `fallbackGlyph` is `emptyGlyphFallback` (both built in), so a plain `createServer()` serves empty tiles and glyphs for anything missing. Pass `null` to either option to return a 404 instead:
 
 ```js
-import {
-  emptyTileFallback,
-  emptyGlyphFallback,
-} from 'styled-map-package-api/fallbacks'
 import { createServer } from 'styled-map-package-api/server'
 
 const server = createServer({
-  fallbackTile: emptyTileFallback,
-  fallbackGlyph: emptyGlyphFallback,
+  fallbackTile: null,
+  fallbackGlyph: null,
 })
 ```
 
 - **`emptyTileFallback(tileId, sourceInfo)`** — Returns an appropriate empty tile based on the source's tile format: empty gzipped MVT for vector sources, 1×1 transparent PNG/WebP for raster sources.
 - **`emptyGlyphFallback(fontstack, range)`** — Returns an empty gzipped PBF (valid protobuf with no glyph entries), causing MapLibre to render missing characters as blank space instead of erroring on a 404.
 
+Both are exported from `styled-map-package-api/fallbacks` if you want to wrap them.
+
 For real glyph rendering with Noto Sans (80+ scripts), use the [`smp-noto-glyphs`](../glyphs/) package:
 
 ```js
 import { notoGlyphFallback } from 'smp-noto-glyphs'
 
+// fallbackTile keeps its default (empty tiles); only the glyph handler is overridden
 const server = createServer({
-  fallbackTile: emptyTileFallback,
   fallbackGlyph: notoGlyphFallback,
 })
 ```
@@ -132,6 +130,17 @@ const server = createServer({
     return fetch(`https://fonts.example.com/${fontstack}/${range}.pbf`)
   },
 })
+```
+
+### Rendering buffer tiles (`expandBounds`)
+
+When `download()` is given a [`bufferTiles`](#downloading-a-map-for-offline-use) value, it downloads extra tile rings around the requested area at every zoom level below maxzoom and records the count as `smp:bufferTiles` in the style metadata. `smp:bounds` is derived from the tile extent at the maximum zoom level (which carries no buffer), so at lower zoom levels these buffer tiles extend geographically beyond the source `bounds` and MapLibre will not request them by default.
+
+By default (`expandBounds: true`) the server widens each tile source's `bounds` to the whole world in the served `style.json`, so the lower-zoom buffer tiles are requested and rendered. The transform only applies when the package has `smp:bufferTiles` metadata, and the stored `style.json` is left unchanged. By default the server also pairs this with the built-in empty-tile fallback, so requests for tiles outside the downloaded area resolve to empty tiles rather than 404s. Pass `expandBounds: false` to disable the widening:
+
+```js
+// expandBounds and the empty-tile/glyph fallbacks are on by default
+const server = createServer()
 ```
 
 ### Downloading a map for offline use
@@ -151,17 +160,20 @@ const stream = download({
 
 **Options:**
 
-| Option              | Type        | Description                                                            |
-| ------------------- | ----------- | ---------------------------------------------------------------------- |
-| `styleUrl`          | `string`    | URL of the map style to download (required)                            |
-| `bbox`              | `BBox`      | Bounding box `[west, south, east, north]` for tile download (required) |
-| `maxzoom`           | `number`    | Maximum zoom level to download (required)                              |
-| `mapboxAccessToken` | `string?`   | Mapbox access token (required for Mapbox styles)                       |
-| `skipLocalGlyphs`   | `boolean?`  | Skip CJK/Hangul/Kana glyph ranges rendered client-side by MapLibre GL  |
-| `dedupe`            | `boolean?`  | Store duplicate tiles only once to reduce file size                    |
-| `onprogress`        | `function?` | Callback receiving a `DownloadProgress` object (see below)             |
+| Option              | Type        | Description                                                                         |
+| ------------------- | ----------- | ----------------------------------------------------------------------------------- |
+| `styleUrl`          | `string`    | URL of the map style to download (required)                                         |
+| `bbox`              | `BBox`      | Bounding box `[west, south, east, north]` for tile download (required)              |
+| `maxzoom`           | `number`    | Maximum zoom level to download (required)                                           |
+| `mapboxAccessToken` | `string?`   | Mapbox access token (required for Mapbox styles)                                    |
+| `skipLocalGlyphs`   | `boolean?`  | Skip CJK/Hangul/Kana glyph ranges rendered client-side by MapLibre GL               |
+| `dedupe`            | `boolean?`  | Store duplicate tiles only once to reduce file size                                 |
+| `bufferTiles`       | `number?`   | Extra tile rings to download around `bbox` at each zoom below maxzoom (default `0`) |
+| `onprogress`        | `function?` | Callback receiving a `DownloadProgress` object (see below)                          |
 
 The `skipLocalGlyphs` option skips downloading glyph ranges that MapLibre GL renders client-side via [`localIdeographFontFamily`](https://maplibre.org/maplibre-gl-js/docs/API/type-aliases/MapOptions/) (CJK, Hangul, Kana, Yi, and Halfwidth/Fullwidth Forms — 163 of 256 ranges). This significantly reduces download size for styles that use these scripts.
+
+The `bufferTiles` option downloads extra tile rings around `bbox` at every zoom level below maxzoom so the map is not clipped at the edges of the downloaded area when zooming out (a single source `bounds` rectangle cannot describe a per-zoom buffer). The buffer is not added at maxzoom. When non-zero it is recorded in the package as `metadata['smp:bufferTiles']`, which `createServer`'s [`expandBounds`](#rendering-buffer-tiles-expandbounds) option can use to render those tiles.
 
 Tile sources may reference either a [TileJSON](https://github.com/mapbox/tilejson-spec) endpoint or a [PMTiles](https://docs.protomaps.com/pmtiles/) archive (`url: "pmtiles://https://…/map.pmtiles"`). PMTiles archives are read over HTTP range requests, and only the tiles within `bbox`/`maxzoom` are downloaded.
 

--- a/packages/api/lib/download.js
+++ b/packages/api/lib/download.js
@@ -26,6 +26,7 @@ import { Writer } from './writer.js'
  * @param {string} [opts.mapboxAccessToken]
  * @param {boolean} [opts.skipLocalGlyphs] Skip glyph ranges rendered client-side by MapLibre GL via localIdeographFontFamily (CJK, Hangul, Kana, Yi, etc.)
  * @param {boolean} [opts.dedupe] When true, duplicate tiles are stored only once (see {@link Writer})
+ * @param {number} [opts.bufferTiles=0] Number of extra tile rings to download around `bbox` at each zoom level below maxzoom, so the map is not clipped at the edges of the downloaded area when zooming out. Recorded in the package as `metadata['smp:bufferTiles']`.
  * @param {AbortSignal} [opts.signal] AbortSignal to cancel the download
  * @returns {import('./types.js').DownloadStream} Readable stream of the output styled map file
  */
@@ -37,6 +38,7 @@ export function download({
   mapboxAccessToken,
   skipLocalGlyphs,
   dedupe,
+  bufferTiles = 0,
   signal: signalExt,
 }) {
   /** @type {ReadableStreamDefaultReader<Uint8Array> | undefined} */
@@ -101,6 +103,7 @@ export function download({
           const tiles = downloader.getTiles({
             bounds: bbox,
             maxzoom,
+            bufferTiles,
             onprogress: (tileStats) =>
               handleProgress({ tiles: { ...tileStats, done: false } }),
           })

--- a/packages/api/lib/pmtiles-downloader.js
+++ b/packages/api/lib/pmtiles-downloader.js
@@ -163,7 +163,7 @@ function singleChunkStream(data) {
  * @param {(progress: TileDownloadStats) => void} [opts.onprogress] Callback to report download progress
  * @param {boolean} [opts.trackErrors=false] Include errors in the returned array of skipped tiles - this has memory overhead so should only be used for debugging.
  * @param {Readonly<BBox>} [opts.sourceBounds=MAX_BOUNDS] Bounding box of source data.
- * @param {boolean} [opts.boundsBuffer=false] Buffer the bounds by one tile at each zoom level to ensure no tiles are missed at the edges.
+ * @param {number} [opts.bufferTiles=0] Number of extra tile rings to download around the bounds at each zoom level below maxzoom, to ensure tiles are not missed at the edges.
  * @param {number} [opts.minzoom=0] Minimum zoom level to download
  * @param {number} [opts.concurrency=8] Number of concurrent tile reads
  * @returns {AsyncGenerator<[ReadableStream<Uint8Array>, TileInfo]> & { readonly skipped: Array<TileInfo & { error?: Error }>, readonly stats: TileDownloadStats }}
@@ -176,7 +176,7 @@ export function downloadPmtilesTiles({
   onprogress = noop,
   trackErrors = false,
   sourceBounds = MAX_BOUNDS,
-  boundsBuffer = false,
+  bufferTiles = 0,
   minzoom = 0,
   concurrency = 8,
 }) {
@@ -188,7 +188,7 @@ export function downloadPmtilesTiles({
   /** @type {ReturnType<downloadPmtilesTiles>} */
   const tiles = (async function* () {
     const coords = [
-      ...tileIterator({ bounds, minzoom, maxzoom, sourceBounds, boundsBuffer }),
+      ...tileIterator({ bounds, minzoom, maxzoom, sourceBounds, bufferTiles }),
     ]
     stats.total = coords.length
     onprogress(stats)

--- a/packages/api/lib/server.js
+++ b/packages/api/lib/server.js
@@ -2,7 +2,9 @@ import { IttyRouter } from 'itty-router/IttyRouter'
 import { StatusError } from 'itty-router/StatusError'
 import { createResponse } from 'itty-router/createResponse'
 
+import { emptyGlyphFallback, emptyTileFallback } from './fallbacks.js'
 import { isFileNotThereError } from './utils/errors.js'
+import { MAX_BOUNDS } from './utils/geo.js'
 import { URI_BASE, templateToRegex } from './utils/templates.js'
 
 /** @import { Resource, Reader } from './reader.js' */
@@ -61,11 +63,17 @@ function json(obj) {
  *
  * @param {object} [options]
  * @param {string} [options.base='/'] Base path for the server routes
- * @param {(tileId: { x: number, y: number, z: number }, sourceInfo: { sourceId: string, source: import('./types.js').SMPSource }) => Response | Promise<Response>} [options.fallbackTile] Called when a tile is missing from the SMP
- * @param {(fontstack: string, range: string) => Response | Promise<Response>} [options.fallbackGlyph] Called when a glyph is missing from the SMP
+ * @param {((tileId: { x: number, y: number, z: number }, sourceInfo: { sourceId: string, source: import('./types.js').SMPSource }) => Response | Promise<Response>) | null} [options.fallbackTile] Called when a tile is missing from the SMP. Defaults to `emptyTileFallback` (format-aware empty tiles); pass `null` to return 404 instead.
+ * @param {((fontstack: string, range: string) => Response | Promise<Response>) | null} [options.fallbackGlyph] Called when a glyph is missing from the SMP. Defaults to `emptyGlyphFallback` (empty PBFs); pass `null` to return 404 instead.
+ * @param {boolean} [options.expandBounds=true] When the package was written with buffer tiles (`metadata['smp:bufferTiles']`), widen each tile source's `bounds` to the whole world in the served `style.json`, so the lower-zoom buffer tiles (which extend beyond `smp:bounds`) are requested and rendered. Pair with `fallbackTile` so that tiles outside the downloaded area resolve to empty tiles rather than 404s.
  * @returns {{ fetch: (request: RequestLike, reader: ReaderLike) => Promise<Response> }} server instance
  */
-export function createServer({ base = '/', fallbackTile, fallbackGlyph } = {}) {
+export function createServer({
+  base = '/',
+  fallbackTile = emptyTileFallback,
+  fallbackGlyph = emptyGlyphFallback,
+  expandBounds = true,
+} = {}) {
   base = base.endsWith('/') ? base : base + '/'
 
   /** @type {WeakMap<ReaderLike, Promise<import('./types.js').SMPStyle>>} */
@@ -96,6 +104,13 @@ export function createServer({ base = '/', fallbackTile, fallbackGlyph } = {}) {
     .get('/style.json', async (request, reader) => {
       const baseUrl = new URL('.', request.url)
       const style = await reader.getStyle(baseUrl.href)
+      if (expandBounds && style.metadata?.['smp:bufferTiles']) {
+        for (const source of Object.values(style.sources)) {
+          if (source.type === 'raster' || source.type === 'vector') {
+            source.bounds = [...MAX_BOUNDS]
+          }
+        }
+      }
       return json(style)
     })
     .get(':path+', async (request, reader) => {

--- a/packages/api/lib/style-downloader.js
+++ b/packages/api/lib/style-downloader.js
@@ -311,10 +311,17 @@ export class StyleDownloader {
    * @param {Readonly<import('./utils/geo.js').BBox>} opts.bounds
    * @param {number} opts.maxzoom
    * @param {(progress: TileDownloadStats) => void} [opts.onprogress]
+   * @param {number} [opts.bufferTiles=0] Number of extra tile rings to download around the bounds at each zoom level below maxzoom, so the map is not clipped at the edges of the downloaded area when zooming out.
    * @param {boolean} [opts.trackErrors=false] Include errors in the returned array of skipped tiles - this has memory overhead so should only be used for debugging.
    * @returns {AsyncGenerator<[ReadableStream<Uint8Array>, TileInfo]> & { readonly skipped: Array<TileInfo & { error?: Error }>, readonly stats: TileDownloadStats }}
    */
-  getTiles({ bounds, maxzoom, onprogress = noop, trackErrors = false }) {
+  getTiles({
+    bounds,
+    maxzoom,
+    onprogress = noop,
+    bufferTiles = 0,
+    trackErrors = false,
+  }) {
     const _this = this
     /** @type {Array<TileInfo & { error?: Error }>} */
     const skipped = []
@@ -354,7 +361,7 @@ export class StyleDownloader {
               maxzoom: Math.min(maxzoom, source.maxzoom || maxzoom),
               minzoom: source.minzoom,
               sourceBounds: source.bounds,
-              boundsBuffer: true,
+              bufferTiles,
               concurrency: _this.#concurrency,
               onprogress: onSourceProgress,
               trackErrors,
@@ -365,7 +372,7 @@ export class StyleDownloader {
               maxzoom: Math.min(maxzoom, source.maxzoom || maxzoom),
               minzoom: source.minzoom,
               sourceBounds: source.bounds,
-              boundsBuffer: true,
+              bufferTiles,
               scheme: source.scheme,
               fetchQueue: _this.#fetchQueue,
               onprogress: onSourceProgress,

--- a/packages/api/lib/tile-downloader.js
+++ b/packages/api/lib/tile-downloader.js
@@ -29,7 +29,7 @@ import { noop } from './utils/misc.js'
  * @param {(progress: TileDownloadStats) => void} [opts.onprogress] Callback to report download progress
  * @param {boolean} [opts.trackErrors=false] Include errors in the returned array of skipped tiles - this has memory overhead so should only be used for debugging.
  * @param {Readonly<import('./utils/geo.js').BBox>} [opts.sourceBounds=MAX_BOUNDS] Bounding box of source data.
- * @param {boolean} [opts.boundsBuffer=false] Buffer the bounds by one tile at each zoom level to ensure no tiles are missed at the edges. With this set to false, in most instances the map will appear incomplete when viewed because the downloaded tiles at lower zoom levels will not cover the map view area.
+ * @param {number} [opts.bufferTiles=0] Number of extra tile rings to download around the bounds at each zoom level below `maxzoom`. A non-zero value ensures tiles are not missed at the edges of the view when the map is panned or zoomed out. The buffer is not applied at `maxzoom`, where it adds storage without improving viewport coverage.
  * @param {number} [opts.minzoom=0] Minimum zoom level to download (for most cases this should be left as `0` - the size overhead is minimal, because each zoom level has 4x as many tiles)
  * @param {number} [opts.concurrency=8] Number of concurrent downloads (ignored if `fetchQueue` is provided)
  * @param {FetchQueue} [opts.fetchQueue=new FetchQueue(concurrency)] Optional fetch queue to use for downloading tiles
@@ -43,7 +43,7 @@ export function downloadTiles({
   onprogress = noop,
   trackErrors = false,
   sourceBounds = MAX_BOUNDS,
-  boundsBuffer = false,
+  bufferTiles = 0,
   minzoom = 0,
   concurrency = 8,
   fetchQueue = new FetchQueue(concurrency),
@@ -92,7 +92,7 @@ export function downloadTiles({
       minzoom,
       maxzoom,
       sourceBounds,
-      boundsBuffer,
+      bufferTiles,
     })
     for (const { x, y, z } of tiles) {
       const tileURL = getTileUrl(tileUrls, { x, y, z, scheme })
@@ -157,7 +157,7 @@ export function downloadTiles({
  * @param {object} opts
  * @param {Readonly<import('./utils/geo.js').BBox>} [opts.bounds]
  * @param {Readonly<import('./utils/geo.js').BBox>} [opts.sourceBounds]
- * @param {boolean} [opts.boundsBuffer]
+ * @param {number} [opts.bufferTiles] Number of extra tile rings to add around the bounds at each zoom level below `maxzoom`. Defaults to `0`.
  * @param {number} [opts.minzoom]
  * @param {number} opts.maxzoom
  */
@@ -166,16 +166,19 @@ export function* tileIterator({
   minzoom = 0,
   maxzoom,
   sourceBounds,
-  boundsBuffer = false,
+  bufferTiles = 0,
 }) {
   const sm = new SphericalMercator({ size: 256 })
+  const maxBuffer = Math.max(0, Math.floor(bufferTiles))
   for (let z = minzoom; z <= maxzoom; z++) {
+    // Buffer improves tile coverage in the viewport when zooming out, so it is
+    // only needed below maxzoom; buffering maxzoom adds disk overhead for no gain.
+    const buffer = z < maxzoom ? maxBuffer : 0
     // Cloning bounds passed to sm.xyz because no guarantee it won't mutate the array
     let { minX, minY, maxX, maxY } = sm.xyz([...bounds], z)
     let sourceXYBounds = sourceBounds
       ? sm.xyz([...sourceBounds], z)
       : { minX, minY, maxX, maxY }
-    const buffer = boundsBuffer ? 1 : 0
     minX = Math.max(0, minX - buffer, sourceXYBounds.minX)
     minY = Math.max(0, minY - buffer, sourceXYBounds.minY)
     maxX = Math.min(Math.pow(2, z) - 1, maxX + buffer, sourceXYBounds.maxX)

--- a/packages/api/lib/validator.js
+++ b/packages/api/lib/validator.js
@@ -372,6 +372,21 @@ function validateMetadata(style, error, warn) {
     )
   }
 
+  // §4.3.4: smp:bufferTiles
+  const bufferTiles = metadata['smp:bufferTiles']
+  if (
+    bufferTiles != null &&
+    (typeof bufferTiles !== 'number' ||
+      !Number.isInteger(bufferTiles) ||
+      bufferTiles < 0)
+  ) {
+    error(
+      'invalid_smp_buffer_tiles',
+      `smp:bufferTiles must be a non-negative integer, got ${bufferTiles}`,
+      'metadata.smp:bufferTiles',
+    )
+  }
+
   // §4.3.3: smp:sourceFolders
   const sourceFolders = metadata['smp:sourceFolders']
   if (sourceFolders && typeof sourceFolders !== 'object') {

--- a/packages/api/lib/writer.js
+++ b/packages/api/lib/writer.js
@@ -1,3 +1,4 @@
+import SphericalMercator from '@mapbox/sphericalmercator'
 import { validateStyleMin, migrate } from '@maplibre/maplibre-gl-style-spec'
 import { bbox } from '@turf/bbox'
 import { excludeKeys } from 'filter-obj'
@@ -26,10 +27,18 @@ import {
 /** @typedef {`${number}-${number}`} GlyphRange */
 /** @typedef {'png' | 'mvt' | 'jpg' | 'webp'} TileFormat */
 /**
+ * @typedef {object} TileExtent
+ * @property {number} minX
+ * @property {number} minY
+ * @property {number} maxX
+ * @property {number} maxY
+ */
+/**
  * @typedef {object} SourceInfo
  * @property {import('./types.js').SMPSource} source
  * @property {string} encodedSourceId
  * @property {TileFormat} [format]
+ * @property {Map<number, TileExtent>} [tileExtents] Tile column/row extent per zoom level, used to infer the bounds buffer (see {@link Writer#getBufferTiles}).
  */
 /**
  * @typedef {object} TileInfo
@@ -209,6 +218,44 @@ export class Writer {
   }
 
   /**
+   * Infer the bounds buffer: the largest number of extra tile rings that extend
+   * beyond a source's `bounds` at any zoom level below its max zoom.
+   *
+   * `bounds` is derived from the tiles at max zoom, so at lower zooms the same
+   * tile coordinates that the buffer added show up as tiles outside `bounds`.
+   * Returns `0` when no source has tiles beyond its bounds (no buffer, or only
+   * max-zoom tiles are present). The value is a hint and may be approximate near
+   * the antimeridian/poles where the buffer is clamped — see spec §4.3.4.
+   *
+   * @returns {number}
+   */
+  #getBufferTiles() {
+    const sm = new SphericalMercator({ size: 256 })
+    let bufferTiles = 0
+    for (const { source, tileExtents } of this.#sources.values()) {
+      if (
+        !tileExtents ||
+        (source.type !== 'raster' && source.type !== 'vector')
+      ) {
+        continue
+      }
+      for (const [z, extent] of tileExtents) {
+        if (z >= source.maxzoom) continue
+        const b = sm.xyz([...source.bounds], z)
+        const ring = Math.max(
+          b.minX - extent.minX,
+          extent.maxX - b.maxX,
+          b.minY - extent.minY,
+          extent.maxY - b.maxY,
+          0,
+        )
+        bufferTiles = Math.max(bufferTiles, ring)
+      }
+    }
+    return bufferTiles
+  }
+
+  /**
    * Add a source definition to the styled map package
    *
    * @param {string} sourceId
@@ -310,6 +357,19 @@ export class Writer {
       source.bounds = bbox
     } else if (z === source.maxzoom) {
       source.bounds = unionBBox([source.bounds, bbox])
+    }
+
+    // Track the tile extent per zoom level so the bounds buffer can be inferred
+    // from how far the lower-zoom tiles extend beyond `source.bounds`.
+    const tileExtents = (sourceInfo.tileExtents ??= new Map())
+    const extent = tileExtents.get(z)
+    if (!extent) {
+      tileExtents.set(z, { minX: x, minY: y, maxX: x, maxY: y })
+    } else {
+      if (x < extent.minX) extent.minX = x
+      if (x > extent.maxX) extent.maxX = x
+      if (y < extent.minY) extent.minY = y
+      if (y > extent.maxY) extent.maxY = y
     }
 
     const name = getTileFilename({ sourceId: encodedSourceId, z, x, y, format })
@@ -486,6 +546,10 @@ export class Writer {
       this.#style.center = [w + (e - w) / 2, s + (n - s) / 2]
     }
     metadata['smp:maxzoom'] = this.#getMaxZoom()
+    const bufferTiles = this.#getBufferTiles()
+    if (bufferTiles > 0) {
+      metadata['smp:bufferTiles'] = bufferTiles
+    }
     /** @type {Record<string, string>} */
     metadata['smp:sourceFolders'] = {}
     for (const [sourceId, { encodedSourceId }] of this.#sources) {

--- a/packages/api/test/server.js
+++ b/packages/api/test/server.js
@@ -1,3 +1,5 @@
+import { ZipReader } from '@gmaclennan/zip-reader'
+import { BufferSource } from '@gmaclennan/zip-reader/buffer-source'
 import { onTestFinished, test } from 'vitest'
 
 import assert from 'node:assert/strict'
@@ -5,8 +7,134 @@ import { fileURLToPath } from 'node:url'
 
 import { Reader } from '../lib/reader.js'
 import { createServer } from '../lib/server.js'
+import { tileIterator } from '../lib/tile-downloader.js'
+import { MAX_BOUNDS } from '../lib/utils/geo.js'
 import { validateStyle } from '../lib/utils/style.js'
 import { replaceVariables } from '../lib/utils/templates.js'
+import { Writer } from '../lib/writer.js'
+import { streamToBuffer } from './utils/stream-consumers.js'
+
+/**
+ * Build an in-memory SMP with a single vector source, optionally with a tile
+ * buffer (which the Writer infers into `smp:bufferTiles`). Returns a Reader.
+ * @param {number} [bufferTiles]
+ */
+async function buildSmp(bufferTiles = 0) {
+  const styleIn = {
+    version: 8,
+    sources: {
+      src: { type: 'vector', tiles: ['https://example.com/{z}/{x}/{y}.mvt'] },
+    },
+    layers: [{ id: 'bg', type: 'background' }],
+  }
+  const writer = new Writer(styleIn)
+  const smpPromise = streamToBuffer(writer.outputStream)
+  // Small area within a much larger source extent so the buffer has effect.
+  const bounds = /** @type {const} */ ([10, 10, 11, 11])
+  const sourceBounds = /** @type {const} */ ([-180, -85, 180, 85])
+  for (const { x, y, z } of tileIterator({
+    minzoom: 0,
+    maxzoom: 5,
+    bounds,
+    sourceBounds,
+    bufferTiles,
+  })) {
+    await writer.addTile(new Uint8Array([1, 2, 3]), {
+      x,
+      y,
+      z,
+      sourceId: 'src',
+      format: 'mvt',
+    })
+  }
+  writer.finish()
+  const smp = await smpPromise
+  return new Reader(await ZipReader.from(new BufferSource(smp)))
+}
+
+/**
+ * @param {Reader} reader
+ * @param {Parameters<typeof createServer>[0]} [opts]
+ */
+async function fetchStyle(reader, opts) {
+  const server = createServer(opts)
+  const response = await server.fetch(
+    new Request('http://example.com/style.json'),
+    reader,
+  )
+  return JSON.parse(new TextDecoder().decode(await response.arrayBuffer()))
+}
+
+test('expandBounds (on by default) widens tile source bounds when smp:bufferTiles is set', async () => {
+  const reader = await buildSmp(1)
+  onTestFinished(() => reader.close())
+
+  const style = await fetchStyle(reader)
+  assert.deepEqual(
+    style.sources.src.bounds,
+    [...MAX_BOUNDS],
+    'bounds widened to global',
+  )
+  assert(style.metadata['smp:bounds'], 'smp:bounds metadata still present')
+  assert.notDeepEqual(
+    style.metadata['smp:bounds'],
+    [...MAX_BOUNDS],
+    'smp:bounds metadata is left untouched',
+  )
+})
+
+test('expandBounds: false leaves tile source bounds untouched even when smp:bufferTiles is set', async () => {
+  const reader = await buildSmp(1)
+  onTestFinished(() => reader.close())
+
+  const style = await fetchStyle(reader, { expandBounds: false })
+  assert.notDeepEqual(
+    style.sources.src.bounds,
+    [...MAX_BOUNDS],
+    'bounds not widened when option is off',
+  )
+})
+
+test('expandBounds is a no-op when package has no bufferTiles metadata', async () => {
+  const reader = await buildSmp()
+  onTestFinished(() => reader.close())
+
+  const style = await fetchStyle(reader, { expandBounds: true })
+  assert.notDeepEqual(
+    style.sources.src.bounds,
+    [...MAX_BOUNDS],
+    'bounds not widened without metadata flag',
+  )
+})
+
+test('default server serves an empty fallback tile for a missing tile', async () => {
+  const reader = await buildSmp()
+  onTestFinished(() => reader.close())
+
+  // s/0/5/0/0 is outside the written bounds ([10,10,11,11]), so it is not in the SMP
+  const server = createServer()
+  const response = await server.fetch(
+    new Request('http://example.com/s/0/5/0/0.mvt.gz'),
+    reader,
+  )
+  assert.equal(response.status, 200, 'missing tile served by default fallback')
+  assert.equal(
+    response.headers.get('content-type'),
+    'application/vnd.mapbox-vector-tile',
+  )
+})
+
+test('fallbackTile: null restores 404 for missing tiles', async () => {
+  const reader = await buildSmp()
+  onTestFinished(() => reader.close())
+
+  const server = createServer({ fallbackTile: null })
+  await assert.rejects(
+    () =>
+      server.fetch(new Request('http://example.com/s/0/5/0/0.mvt.gz'), reader),
+    { status: 404 },
+  )
+})
 
 test('server basic', async () => {
   const filepath = fileURLToPath(

--- a/packages/api/test/spec-compliance.js
+++ b/packages/api/test/spec-compliance.js
@@ -674,10 +674,10 @@ describe('Spec §9: Resource integrity', () => {
 // Section 9.1: Missing resources — server fallback behavior
 // ============================================================================
 describe('Spec §9.1: Missing resources — server behavior', () => {
-  test('Server returns 404 for missing tile', async () => {
+  test('Server returns 404 for missing tile when fallback is disabled', async () => {
     const smpBuf = await createValidSmp()
     const reader = await readerFromBuffer(smpBuf)
-    const server = createServer()
+    const server = createServer({ fallbackTile: null })
     await assert.rejects(
       server.fetch(
         new Request('http://example.com/s/0/99/99/99.mvt.gz'),

--- a/packages/api/test/tile-downloader.js
+++ b/packages/api/test/tile-downloader.js
@@ -43,30 +43,99 @@ describe('tileIterator', () => {
     assert(constrained.some((t) => t.z === 0))
   })
 
-  test('boundsBuffer adds extra tiles at edges', () => {
-    // boundsBuffer only has effect when sourceBounds is larger than bounds
+  test('bufferTiles adds extra tile rings at edges', () => {
+    // bufferTiles only has effect when sourceBounds is larger than bounds
     const bounds = /** @type {const} */ ([10, 10, 20, 20])
     const sourceBounds = /** @type {const} */ ([-180, -85, 180, 85])
     const withoutBuffer = [
-      ...tileIterator({
-        bounds,
-        maxzoom: 3,
-        boundsBuffer: false,
-        sourceBounds,
-      }),
+      ...tileIterator({ bounds, maxzoom: 3, bufferTiles: 0, sourceBounds }),
     ]
-    const withBuffer = [
-      ...tileIterator({
-        bounds,
-        maxzoom: 3,
-        boundsBuffer: true,
-        sourceBounds,
-      }),
+    const oneRing = [
+      ...tileIterator({ bounds, maxzoom: 3, bufferTiles: 1, sourceBounds }),
+    ]
+    const twoRings = [
+      ...tileIterator({ bounds, maxzoom: 3, bufferTiles: 2, sourceBounds }),
     ]
     assert(
-      withBuffer.length > withoutBuffer.length,
-      `buffer (${withBuffer.length}) > no buffer (${withoutBuffer.length})`,
+      oneRing.length > withoutBuffer.length,
+      `1 ring (${oneRing.length}) > no buffer (${withoutBuffer.length})`,
     )
+    assert(
+      twoRings.length > oneRing.length,
+      `2 rings (${twoRings.length}) > 1 ring (${oneRing.length})`,
+    )
+  })
+
+  test('bufferTiles defaults to 0 (no buffer)', () => {
+    const bounds = /** @type {const} */ ([10, 10, 20, 20])
+    const sourceBounds = /** @type {const} */ ([-180, -85, 180, 85])
+    const defaulted = [...tileIterator({ bounds, maxzoom: 3, sourceBounds })]
+    const explicitZero = [
+      ...tileIterator({ bounds, maxzoom: 3, bufferTiles: 0, sourceBounds }),
+    ]
+    assert.deepEqual(defaulted, explicitZero)
+  })
+
+  test('bufferTiles of N expands the tile range by N at each edge below maxzoom', () => {
+    // Small bounds, large source so the buffer is not clamped. Zoom 8 is below
+    // maxzoom (9), so the buffer applies there.
+    const bounds = /** @type {const} */ ([10, 10, 11, 11])
+    const sourceBounds = /** @type {const} */ ([-180, -85, 180, 85])
+    const atZoom = (/** @type {{x:number,y:number,z:number}[]} */ tiles) =>
+      tiles.filter((t) => t.z === 8)
+    const baseTiles = atZoom([
+      ...tileIterator({
+        bounds,
+        minzoom: 8,
+        maxzoom: 9,
+        bufferTiles: 0,
+        sourceBounds,
+      }),
+    ])
+    const baseXs = baseTiles.map((t) => t.x)
+    const baseYs = baseTiles.map((t) => t.y)
+    const buffered = atZoom([
+      ...tileIterator({
+        bounds,
+        minzoom: 8,
+        maxzoom: 9,
+        bufferTiles: 2,
+        sourceBounds,
+      }),
+    ])
+    const bufferedXs = buffered.map((t) => t.x)
+    const bufferedYs = buffered.map((t) => t.y)
+    assert.equal(Math.min(...bufferedXs), Math.min(...baseXs) - 2)
+    assert.equal(Math.max(...bufferedXs), Math.max(...baseXs) + 2)
+    assert.equal(Math.min(...bufferedYs), Math.min(...baseYs) - 2)
+    assert.equal(Math.max(...bufferedYs), Math.max(...baseYs) + 2)
+  })
+
+  test('bufferTiles is not applied at maxzoom', () => {
+    // The buffer improves coverage when zooming out, so maxzoom gets no buffer.
+    const bounds = /** @type {const} */ ([10, 10, 11, 11])
+    const sourceBounds = /** @type {const} */ ([-180, -85, 180, 85])
+    const atMaxzoom = (/** @type {{x:number,y:number,z:number}[]} */ tiles) =>
+      tiles.filter((t) => t.z === 8)
+    const base = atMaxzoom([
+      ...tileIterator({
+        bounds,
+        minzoom: 8,
+        maxzoom: 8,
+        bufferTiles: 0,
+        sourceBounds,
+      }),
+    ])
+    const buffered = atMaxzoom([
+      ...tileIterator({
+        bounds,
+        minzoom: 8,
+        maxzoom: 8,
+        bufferTiles: 2,
+        sourceBounds,
+      }),
+    ])
+    assert.deepEqual(buffered, base)
   })
 
   test('small bounds yields few tiles per zoom', () => {

--- a/packages/api/test/utils/global-setup.js
+++ b/packages/api/test/utils/global-setup.js
@@ -20,7 +20,8 @@ export default async function setup({ provide }) {
     new URL('../fixtures/demotiles-z2.smp', import.meta.url),
   )
   const reader = new Reader(fixturePath)
-  const smpServer = createSMPServer()
+  // Emulate a real origin server: missing tiles/glyphs return 404, not fallbacks.
+  const smpServer = createSMPServer({ fallbackTile: null, fallbackGlyph: null })
 
   const adapter = createServerAdapter((request) => {
     return smpServer

--- a/packages/api/test/utils/smp-server.js
+++ b/packages/api/test/utils/smp-server.js
@@ -14,7 +14,8 @@ import { createServer } from '../../lib/server.js'
  */
 export async function startSMPServer(fixturePath) {
   const reader = new Reader(fixturePath)
-  const smpServer = createServer()
+  // Emulate a real origin server: missing tiles/glyphs return 404, not fallbacks.
+  const smpServer = createServer({ fallbackTile: null, fallbackGlyph: null })
   const httpServer = createHTTPServer(
     createServerAdapter((request) =>
       smpServer.fetch(request, reader).catch(error),

--- a/packages/api/test/validator.test.js
+++ b/packages/api/test/validator.test.js
@@ -448,6 +448,91 @@ describe('validate — SMP metadata (§4.3)', () => {
     }
   })
 
+  test('smp:bufferTiles non-negative integer → valid', async () => {
+    for (const bufferTiles of [0, 1, 2]) {
+      const filepath = await createZipFile([
+        { name: 'VERSION', data: '1.0\n' },
+        {
+          name: 'style.json',
+          data: JSON.stringify({
+            version: 8,
+            sources: {},
+            layers: [],
+            metadata: {
+              'smp:bounds': [-180, -85, 180, 85],
+              'smp:maxzoom': 5,
+              'smp:bufferTiles': bufferTiles,
+            },
+          }),
+        },
+      ])
+      const result = await validate(filepath)
+      assert(
+        !hasError(result, 'invalid_smp_buffer_tiles'),
+        `bufferTiles ${bufferTiles} should be valid`,
+      )
+    }
+  })
+
+  test('smp:bufferTiles non-integer → error', async () => {
+    const filepath = await createZipFile([
+      { name: 'VERSION', data: '1.0\n' },
+      {
+        name: 'style.json',
+        data: JSON.stringify({
+          version: 8,
+          sources: {},
+          layers: [],
+          metadata: {
+            'smp:bounds': [-180, -85, 180, 85],
+            'smp:maxzoom': 5,
+            'smp:bufferTiles': 1.5,
+          },
+        }),
+      },
+    ])
+    const result = await validate(filepath)
+    assert(hasError(result, 'invalid_smp_buffer_tiles'))
+  })
+
+  test('smp:bufferTiles negative → error', async () => {
+    const filepath = await createZipFile([
+      { name: 'VERSION', data: '1.0\n' },
+      {
+        name: 'style.json',
+        data: JSON.stringify({
+          version: 8,
+          sources: {},
+          layers: [],
+          metadata: {
+            'smp:bounds': [-180, -85, 180, 85],
+            'smp:maxzoom': 5,
+            'smp:bufferTiles': -1,
+          },
+        }),
+      },
+    ])
+    const result = await validate(filepath)
+    assert(hasError(result, 'invalid_smp_buffer_tiles'))
+  })
+
+  test('missing smp:bufferTiles is valid (optional)', async () => {
+    const filepath = await createZipFile([
+      { name: 'VERSION', data: '1.0\n' },
+      {
+        name: 'style.json',
+        data: JSON.stringify({
+          version: 8,
+          sources: {},
+          layers: [],
+          metadata: { 'smp:bounds': [-180, -85, 180, 85], 'smp:maxzoom': 5 },
+        }),
+      },
+    ])
+    const result = await validate(filepath)
+    assert(!hasError(result, 'invalid_smp_buffer_tiles'))
+  })
+
   test('missing smp:sourceFolders is valid (optional)', async () => {
     const filepath = await createZipFile([
       { name: 'VERSION', data: '1.0\n' },

--- a/packages/api/test/write-read.js
+++ b/packages/api/test/write-read.js
@@ -6,7 +6,7 @@ import { describe, expect, test } from 'vitest'
 
 import { Reader } from '../lib/reader.js'
 import { tileIterator } from '../lib/tile-downloader.js'
-import { unionBBox } from '../lib/utils/geo.js'
+import { MAX_BOUNDS, unionBBox } from '../lib/utils/geo.js'
 import { Writer } from '../lib/writer.js'
 import { assertBboxEqual } from './utils/assert-bbox-equal.js'
 import { DigestStream } from './utils/digest-stream.js'
@@ -154,6 +154,90 @@ test('Minimal write & read', async () => {
       tileHashes.get(`${z}/${x}/${y}`),
     )
   }
+})
+
+describe('bufferTiles metadata (inferred)', () => {
+  // The buffer only has effect when sourceBounds is larger than bounds, so the
+  // tiles cover a small area within a much larger source extent.
+  const defaultBounds = /** @type {BBox} */ ([10, 10, 11, 11])
+  const defaultSourceBounds = /** @type {BBox} */ ([-180, -85, 180, 85])
+
+  /**
+   * @param {number} bufferTiles
+   * @param {{ bounds?: BBox, sourceBounds?: BBox }} [opts]
+   */
+  async function writeWithBuffer(
+    bufferTiles,
+    { bounds = defaultBounds, sourceBounds = defaultSourceBounds } = {},
+  ) {
+    const styleIn = await readJson(
+      new URL('./fixtures/valid-styles/minimal.input.json', import.meta.url),
+    )
+    const writer = new Writer(styleIn)
+    const smpPromise = streamToBuffer(writer.outputStream)
+    for (const { x, y, z } of tileIterator({
+      minzoom: 0,
+      maxzoom: 5,
+      bounds,
+      sourceBounds,
+      bufferTiles,
+    })) {
+      await writer.addTile(randomWebStream({ size: random(256, 1024) }), {
+        x,
+        y,
+        z,
+        sourceId: 'maplibre',
+        format: 'mvt',
+      })
+    }
+    writer.finish()
+    const smp = await smpPromise
+    const reader = new Reader(await ZipReader.from(new BufferSource(smp)))
+    return (await reader.getStyle()).metadata
+  }
+
+  test('infers smp:bufferTiles = 1 from a one-ring buffer', async () => {
+    const metadata = await writeWithBuffer(1)
+    expect(metadata['smp:bufferTiles']).toBe(1)
+  })
+
+  test('infers smp:bufferTiles = 2 from a two-ring buffer', async () => {
+    const metadata = await writeWithBuffer(2)
+    expect(metadata['smp:bufferTiles']).toBe(2)
+  })
+
+  test('omits smp:bufferTiles when there is no buffer', async () => {
+    const metadata = await writeWithBuffer(0)
+    expect('smp:bufferTiles' in metadata).toBe(false)
+  })
+
+  // When a bounds side sits on the Web Mercator extent the buffer is clamped to
+  // 0 on that axis, so the inference must rely on the unclamped axis.
+  const [west, south, east, north] = MAX_BOUNDS
+
+  test('infers smp:bufferTiles when bounds span the full longitude (east-west edges clamped)', async () => {
+    const metadata = await writeWithBuffer(1, {
+      bounds: [west, 10, east, 11],
+      sourceBounds: [...MAX_BOUNDS],
+    })
+    expect(metadata['smp:bufferTiles']).toBe(1)
+  })
+
+  test('infers smp:bufferTiles when bounds span the full latitude (north-south edges clamped)', async () => {
+    const metadata = await writeWithBuffer(1, {
+      bounds: [10, south, 11, north],
+      sourceBounds: [...MAX_BOUNDS],
+    })
+    expect(metadata['smp:bufferTiles']).toBe(1)
+  })
+
+  test('infers smp:bufferTiles for a small area in the NE corner (north + east edges clamped)', async () => {
+    const metadata = await writeWithBuffer(1, {
+      bounds: [170, 80, east, north],
+      sourceBounds: [...MAX_BOUNDS],
+    })
+    expect(metadata['smp:bufferTiles']).toBe(1)
+  })
 })
 
 test('Inline GeoJSON is not removed from style', async () => {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,16 +25,22 @@ smp download https://demotiles.maplibre.org/style.json \
 
 **Options:**
 
-| Option                 | Description                                                       |
-| ---------------------- | ----------------------------------------------------------------- |
-| `-o, --output <file>`  | Output file (writes to stdout if omitted)                         |
-| `-b, --bbox <w,s,e,n>` | Bounding box (west, south, east, north)                           |
-| `-z, --zoom <number>`  | Max zoom level (0-22)                                             |
-| `-t, --token <token>`  | Mapbox access token (required for Mapbox styles)                  |
-| `-d, --dedupe`         | Deduplicate tiles with identical content to reduce file size      |
-| `--skip-local-glyphs`  | Skip CJK/Hangul/Kana glyph ranges rendered locally by MapLibre GL |
+| Option                 | Description                                                            |
+| ---------------------- | ---------------------------------------------------------------------- |
+| `-o, --output <file>`  | Output file (writes to stdout if omitted)                              |
+| `-b, --bbox <w,s,e,n>` | Bounding box (west, south, east, north)                                |
+| `-z, --zoom <number>`  | Max zoom level (0-22)                                                  |
+| `-t, --token <token>`  | Mapbox access token (required for Mapbox styles)                       |
+| `-d, --dedupe`         | Deduplicate tiles with identical content to reduce file size           |
+| `--skip-local-glyphs`  | Skip CJK/Hangul/Kana glyph ranges rendered locally by MapLibre GL      |
+| `--buffer-tiles`       | Download an extra tile ring around the bbox at each zoom below maxzoom |
 
 When run interactively, missing options are prompted for.
+
+The `--buffer-tiles` flag downloads one extra tile ring around the bbox at every
+zoom level below maxzoom, so the map is not clipped at the edges of the
+downloaded area when zooming out. The buffer is not added at maxzoom. `smp view`
+automatically renders these buffer tiles.
 
 ### `smp view`
 
@@ -46,13 +52,15 @@ smp view demotiles.smp --open
 
 **Options:**
 
-| Option                | Description                                                                 |
-| --------------------- | --------------------------------------------------------------------------- |
-| `-o, --open`          | Open in the default web browser                                             |
-| `-p, --port <number>` | Port to serve on (default: 3000)                                            |
-| `-f, --fallback`      | Serve empty tiles and Noto Sans glyphs for missing resources instead of 404 |
+| Option                | Description                                                                |
+| --------------------- | -------------------------------------------------------------------------- |
+| `-o, --open`          | Open in the default web browser                                            |
+| `-p, --port <number>` | Port to serve on (default: 3000)                                           |
+| `--no-fallback`       | Return 404 for missing tiles and glyphs instead of serving empty fallbacks |
 
-The `--fallback` flag is useful for previewing SMP files that don't contain every tile or glyph range referenced by the style. Missing vector tiles are served as empty MVTs, missing raster tiles as transparent pixels. Missing glyph ranges are served using bundled [Noto Sans](https://fonts.google.com/noto/specimen/Noto+Sans) glyphs (via [GoNotoKurrent](https://github.com/satbyy/go-noto-universal), covering 80+ scripts including Latin, Cyrillic, Greek, Arabic, Hebrew, Devanagari, Thai, and more). CJK and Hangul ranges are not bundled since MapLibre renders these client-side via `localIdeographFontFamily`.
+By default the viewer serves empty tiles and Noto Sans glyphs for any resource not present in the file, so incomplete packages (those covering a partial area or zoom range) preview without 404 errors. Missing vector tiles are served as empty MVTs, missing raster tiles as transparent pixels. Missing glyph ranges are served using bundled [Noto Sans](https://fonts.google.com/noto/specimen/Noto+Sans) glyphs (via [GoNotoKurrent](https://github.com/satbyy/go-noto-universal), covering 80+ scripts including Latin, Cyrillic, Greek, Arabic, Hebrew, Devanagari, Thai, and more). CJK and Hangul ranges are not bundled since MapLibre renders these client-side via `localIdeographFontFamily`. Pass `--no-fallback` to return 404s instead.
+
+For packages downloaded with buffer tiles (recorded as `smp:bufferTiles` in the style metadata), the viewer also widens each source's `bounds` so the lower-zoom buffer tiles that extend beyond the data area are rendered rather than clipped. Combined with the empty-tile fallback, panning beyond the downloaded area shows blank tiles instead of console errors.
 
 ### `smp mbtiles`
 

--- a/packages/cli/bin/smp-download.js
+++ b/packages/cli/bin/smp-download.js
@@ -41,14 +41,27 @@ program
     '-d, --dedupe',
     'deduplicate tiles with identical content to reduce file size',
   )
+  .option(
+    '--buffer-tiles',
+    'download an extra tile ring around the bbox at each zoom level below maxzoom, so the map is not clipped at the edges when zooming out',
+  )
   .argument('[styleUrl]', 'URL to style to download', parseUrl)
   .action(
     async (
       styleUrl,
-      { bbox, zoom, output, token, skipLocalGlyphs, dedupe },
+      { bbox, zoom, output, token, skipLocalGlyphs, dedupe, bufferTiles },
     ) => {
       await runDownload(
-        { styleUrl, bbox, zoom, output, token, skipLocalGlyphs, dedupe },
+        {
+          styleUrl,
+          bbox,
+          zoom,
+          output,
+          token,
+          skipLocalGlyphs,
+          dedupe,
+          bufferTiles,
+        },
         {
           download,
           prompt: { input, number },

--- a/packages/cli/bin/smp-view.js
+++ b/packages/cli/bin/smp-view.js
@@ -20,8 +20,8 @@ program
   .option('-o, --open', 'open in the default web browser')
   .option('-p, --port <number>', 'port to serve on', (v) => parseInt(v), 3000)
   .option(
-    '-f, --fallback',
-    'serve empty tiles and glyphs for missing resources instead of 404',
+    '--no-fallback',
+    'return 404 for missing tiles and glyphs instead of serving empty fallbacks',
   )
   .argument('<file>', 'file to serve')
   .action(async (filepath, { open, port, fallback }) => {

--- a/packages/cli/lib/commands/download.js
+++ b/packages/cli/lib/commands/download.js
@@ -59,6 +59,7 @@ export function parseUrl(url) {
  * @property {string | undefined} token
  * @property {boolean | undefined} skipLocalGlyphs
  * @property {boolean | undefined} dedupe
+ * @property {boolean | undefined} bufferTiles When set, download one extra tile ring around the bbox at each zoom level below maxzoom.
  */
 
 /**
@@ -77,7 +78,7 @@ export function parseUrl(url) {
  * @param {DownloadDeps} deps
  */
 export async function runDownload(
-  { styleUrl, bbox, zoom, output, token, skipLocalGlyphs, dedupe },
+  { styleUrl, bbox, zoom, output, token, skipLocalGlyphs, dedupe, bufferTiles },
   deps,
 ) {
   const { download, prompt, isMapboxURL, mapboxApiUrl, isTTY } = deps
@@ -181,6 +182,8 @@ export async function runDownload(
     mapboxAccessToken: token,
     skipLocalGlyphs,
     dedupe,
+    // `--buffer-tiles` is a boolean flag on the CLI; map it to a one-tile ring.
+    bufferTiles: bufferTiles ? 1 : 0,
   })
   const outputStream = deps.createOutputStream(output)
   await readStream.pipeTo(

--- a/packages/cli/lib/commands/view.js
+++ b/packages/cli/lib/commands/view.js
@@ -3,7 +3,7 @@
  * @property {number} port
  * @property {string} filepath
  * @property {boolean} [open]
- * @property {boolean} [fallback]
+ * @property {boolean} [fallback] Serve empty tiles and fallback glyphs for missing resources. Defaults to `true`; pass `false` to return 404s instead.
  */
 
 /**
@@ -26,13 +26,19 @@
 export async function runView({ port, filepath, open, fallback }, deps) {
   const { Reader, createServer, openApp, log, readViewerHtml } = deps
 
+  // Fallback is on by default; pass `fallback: false` to disable it. Pass the
+  // handlers explicitly (null to disable) rather than relying on the server's
+  // own defaults, since the CLI uses Noto glyphs rather than empty ones.
+  const useFallback = fallback !== false
+
   const reader = new Reader(filepath)
   const smpServer = createServer({
     base: '/map',
-    ...(fallback && {
-      fallbackTile: deps.emptyTileFallback,
-      fallbackGlyph: deps.emptyGlyphFallback,
-    }),
+    // Render buffer tiles that lie outside the data bounds for packages written
+    // with `smp:bufferTiles`. No-op for packages without that metadata.
+    expandBounds: true,
+    fallbackTile: useFallback ? deps.emptyTileFallback : null,
+    fallbackGlyph: useFallback ? deps.emptyGlyphFallback : null,
   })
 
   /** @param {Request} request */

--- a/packages/cli/test/__snapshots__/help.js.snap
+++ b/packages/cli/test/__snapshots__/help.js.snap
@@ -35,6 +35,10 @@ Options:
                                       rendered locally by MapLibre GL
   -d, --dedupe                        deduplicate tiles with identical content
                                       to reduce file size
+  --buffer-tiles                      download an extra tile ring around the
+                                      bbox at each zoom level below maxzoom, so
+                                      the map is not clipped at the edges when
+                                      zooming out
   -h, --help                          display help for command
 "
 `;
@@ -64,8 +68,8 @@ Arguments:
 Options:
   -o, --open           open in the default web browser
   -p, --port <number>  port to serve on (default: 3000)
-  -f, --fallback       serve empty tiles and glyphs for missing resources
-                       instead of 404
+  --no-fallback        return 404 for missing tiles and glyphs instead of
+                       serving empty fallbacks
   -h, --help           display help for command
 "
 `;

--- a/packages/cli/test/commands/download.js
+++ b/packages/cli/test/commands/download.js
@@ -308,6 +308,45 @@ describe('runDownload', () => {
     )
   })
 
+  test('bufferTiles flag maps to a one-tile ring', async () => {
+    const deps = makeDeps()
+
+    await runDownload(
+      {
+        styleUrl: 'https://example.com/style.json',
+        bbox: [11, 47, 12, 47.5],
+        zoom: 5,
+        output: 'out.smp',
+        token: undefined,
+        bufferTiles: true,
+      },
+      deps,
+    )
+
+    expect(deps.download).toHaveBeenCalledWith(
+      expect.objectContaining({ bufferTiles: 1 }),
+    )
+  })
+
+  test('no bufferTiles flag means no buffer', async () => {
+    const deps = makeDeps()
+
+    await runDownload(
+      {
+        styleUrl: 'https://example.com/style.json',
+        bbox: [11, 47, 12, 47.5],
+        zoom: 5,
+        output: 'out.smp',
+        token: undefined,
+      },
+      deps,
+    )
+
+    expect(deps.download).toHaveBeenCalledWith(
+      expect.objectContaining({ bufferTiles: 0 }),
+    )
+  })
+
   test('prompts for output when TTY and missing required args', async () => {
     const deps = makeDeps({ isTTY: true })
     deps.prompt.input

--- a/packages/cli/test/commands/view.js
+++ b/packages/cli/test/commands/view.js
@@ -3,6 +3,9 @@ import { describe, expect, test, vi } from 'vitest'
 import { runView } from '../../lib/commands/view.js'
 
 describe('runView', () => {
+  const emptyTileFallback = vi.fn()
+  const emptyGlyphFallback = vi.fn()
+
   function makeDeps(overrides = {}) {
     return {
       Reader: vi.fn().mockImplementation(() => ({ getStyle: vi.fn() })),
@@ -14,9 +17,9 @@ describe('runView', () => {
       readViewerHtml: vi
         .fn()
         .mockResolvedValue(new Uint8Array([60, 104, 116, 109, 108, 62])), // <html>
-      listen: vi
-        .fn()
-        .mockResolvedValue('http://127.0.0.1:3000'),
+      listen: vi.fn().mockResolvedValue('http://127.0.0.1:3000'),
+      emptyTileFallback,
+      emptyGlyphFallback,
       ...overrides,
     }
   }
@@ -29,12 +32,37 @@ describe('runView', () => {
     expect(deps.Reader).toHaveBeenCalledWith('test.smp')
   })
 
-  test('creates server with /map base', async () => {
+  test('creates server with /map base, expandBounds, and fallbacks by default', async () => {
     const deps = makeDeps()
 
     await runView({ port: 3000, filepath: 'test.smp' }, deps)
 
-    expect(deps.createServer).toHaveBeenCalledWith({ base: '/map' })
+    expect(deps.createServer).toHaveBeenCalledWith({
+      base: '/map',
+      expandBounds: true,
+      fallbackTile: deps.emptyTileFallback,
+      fallbackGlyph: deps.emptyGlyphFallback,
+    })
+  })
+
+  test('always enables expandBounds', async () => {
+    const deps = makeDeps()
+
+    await runView({ port: 3000, filepath: 'test.smp', fallback: false }, deps)
+
+    expect(deps.createServer).toHaveBeenCalledWith(
+      expect.objectContaining({ expandBounds: true }),
+    )
+  })
+
+  test('fallback: false disables the fallback handlers', async () => {
+    const deps = makeDeps()
+
+    await runView({ port: 3000, filepath: 'test.smp', fallback: false }, deps)
+
+    expect(deps.createServer).toHaveBeenCalledWith(
+      expect.objectContaining({ fallbackTile: null, fallbackGlyph: null }),
+    )
   })
 
   test('logs server address', async () => {
@@ -50,10 +78,7 @@ describe('runView', () => {
   test('returns the server address', async () => {
     const deps = makeDeps()
 
-    const address = await runView(
-      { port: 3000, filepath: 'test.smp' },
-      deps,
-    )
+    const address = await runView({ port: 3000, filepath: 'test.smp' }, deps)
 
     expect(address).toBe('http://127.0.0.1:3000')
   })
@@ -102,9 +127,7 @@ describe('runView', () => {
 
   test('handler delegates /map/* to smpServer', async () => {
     const deps = makeDeps()
-    const mockFetch = vi
-      .fn()
-      .mockResolvedValue(new Response('tile'))
+    const mockFetch = vi.fn().mockResolvedValue(new Response('tile'))
     deps.createServer.mockReturnValue({ fetch: mockFetch })
 
     deps.listen.mockImplementation(async (_port, handler) => {

--- a/spec/1.0/README.md
+++ b/spec/1.0/README.md
@@ -201,6 +201,16 @@ Example:
 
 This indicates that tiles for the `openmaptiles` source are stored under `s/0/` and tiles for `hillshade` are stored under `s/1/`. The `s/` prefix and the subfolder names (`0`, `1`) are both implementation-defined — other writers MAY use different paths.
 
+#### 4.3.4 `smp:bufferTiles` (OPTIONAL)
+
+- Type: Non-negative integer
+- Indicates that tile sources include up to this many extra rings of tiles around the data at zoom levels below each source's `maxzoom`. A value of `1` means up to a one-tile border was added around the data at the lower zoom levels; absent or `0` means no buffer was applied.
+- The value is the largest buffer observed across all sources and zoom levels, and is only a hint: an individual source or zoom level MAY carry a smaller buffer — for example where the buffer is clamped at the antimeridian or the poles.
+- Writers add a buffer so that, when a consumer zooms out from the region the package covers, the tiles just outside the visible edge are present and the map does not appear clipped at the boundary. The buffer is not applied at a source's `maxzoom`, where it would add storage without improving coverage of the viewport.
+- A tile source's `bounds` reflects its tile extent at its own `maxzoom`, which carries no buffer, so it describes the requested area exactly (`smp:bounds` is the union of those extents). At lower zoom levels each tile covers a far larger area, so the buffer there extends geographically beyond that rectangle; those lower-zoom buffer tiles therefore lie outside `bounds`.
+- These extra tiles are OPTIONAL and do not change the completeness requirement: completeness is defined relative to `smp:bounds` (see [Section 5.8](#58-tile-bounds-and-completeness)). Clients MUST NOT rely on buffer tiles being present.
+- Because a tile source's `bounds` is a single rectangle, it cannot describe a per-zoom buffer. A consumer that wants to render the lower-zoom buffer tiles MAY, at serve time, widen each tile source's `bounds` (e.g. to the whole world) so that mapping libraries request them. When doing so, the consumer SHOULD also serve empty tiles for requests that fall outside the available data, since widening `bounds` will cause requests for tiles that are not present.
+
 ### 4.4 Additional Style Properties
 
 The standard [MapLibre Style Specification](https://maplibre.org/maplibre-style-spec/) properties `center` and `zoom`, if set, SHOULD be consistent with the data in the package — i.e. `center` SHOULD be within `smp:bounds` and `zoom` SHOULD be within the zoom range of the tile data (between `minzoom` and `smp:maxzoom`).
@@ -289,9 +299,11 @@ Readers and serving implementations MUST return the `attribution` property unmod
 
 ### 5.8 Tile Bounds and Completeness
 
-The `bounds` property of a tile source MUST reflect the geographic extent of available tile data, as defined by the [TileJSON specification](https://github.com/mapbox/tilejson-spec). It represents the bounding box within which tile data is present and MAY be used by clients to limit requests to this region.
+The `bounds` property of a tile source MUST reflect the geographic extent of available tile data at the source's maximum zoom level, as defined by the [TileJSON specification](https://github.com/mapbox/tilejson-spec). It represents the bounding box within which tile data is present and MAY be used by clients to limit requests to this region.
 
 All tiles at zoom levels between `minzoom` and `maxzoom` (inclusive) that intersect the source's `bounds` MUST be present in the archive.
+
+A package MAY contain additional tiles that lie outside the source's `bounds` — for example lower-zoom buffer tiles (see [Section 4.3.4](#434-smpbuffertiles-optional)), which can extend beyond a `bounds` derived from the maximum-zoom extent. Such extra tiles are permitted and do not affect the completeness requirement above.
 
 ## 6. Fonts (Glyphs)
 


### PR DESCRIPTION
Buffer tiles are extra tile rings downloaded around the requested area at each zoom level below maxzoom, so the map is not clipped at the edges of the downloaded area when zooming out. The buffer is not applied at maxzoom, where it would add disk overhead without improving viewport coverage.

- Adds a `bufferTiles` option (a non-negative integer ring count, default `0`) to `download()`, `StyleDownloader#getTiles`, `downloadTiles`, `downloadPmtilesTiles`, and `tileIterator`. Replaces the previous boolean `boundsBuffer`. Exposed on the CLI as the boolean flag `smp download --buffer-tiles` (one ring).
- Records the buffer in the style metadata as `smp:bufferTiles` (new spec §4.3.4). The `Writer` infers this value from the tiles it receives — the number of extra tile rings that extend beyond the max-zoom `bounds`.
- Adds an `expandBounds` option to `createServer`, enabled by default. When the package has `smp:bufferTiles` metadata, each tile source's `bounds` is widened to the whole world in the served `style.json` (the stored file is unchanged), so the lower-zoom buffer tiles are rendered. Combined with the default empty-tile fallback, this serves empty tiles outside the downloaded area. Pass `expandBounds: false` to disable.
- `createServer` now defaults `fallbackTile`/`fallbackGlyph` to the built-in empty fallbacks, so a plain `createServer()` serves empty tiles/glyphs for missing resources instead of returning 404. Pass `null` for either option to restore 404 behavior.
- `smp view` now enables `expandBounds` and serves empty-tile/glyph fallbacks by default. The previous `-f, --fallback` flag is replaced by `--no-fallback` to opt out.